### PR TITLE
expose CLIENT_ID and KEYCLOAK_URL as vars from docker-compose, add NE…

### DIFF
--- a/app/db/utils.js
+++ b/app/db/utils.js
@@ -60,6 +60,10 @@ function queryBuilder(name, { queryParams='', body='', method='' }) {
         filter = '=';
       } else if (filter === 'eq' && isNull) {
         filter = 'IS';
+      } else if (filter === 'neq' && !isNull) {
+        filter = '!=';
+      } else if (filter === 'neq' && isNull) {
+        filter = 'IS NOT';
       } else {
         filter = 'IN';
         value = value.replace('%28', '').replace('%29', '').replace(/%20/g, ' ');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,8 @@ services:
       LOG_LEVEL: debug
       PORT: 5000
       DB_CONNECTION_STRING: postgres://authenticatoroperation:auth1234@postgres_operational_data:5432/operation
-      CLIENT_ID: cop-data-api
-      KEYCLOAK_URL: http://keycloak.lodev.xyz/auth/realms/dev
+      CLIENT_ID: ${CLIENT_ID}
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
     depends_on:
       - postgres_operational_data
       - operational_flyway

--- a/test/db/utils.test.js
+++ b/test/db/utils.test.js
@@ -47,9 +47,21 @@ describe('Test querystring builder', () => {
       expect(query).to.equal(expectedQuery);
     });
 
+    it('Should return a querystring for all data where email does not match user email', () => {
+      const expectedQuery = 'SELECT * FROM users WHERE email != \'john@mail.com\';';
+      const query = queryBuilder('users', { queryParams: 'email=neq.john@mail.com' });
+      expect(query).to.equal(expectedQuery);
+    });
+
     it('Should return a querystring for all data where name is null', () => {
       const expectedQuery = 'SELECT * FROM users WHERE name IS NULL;';
       const query = queryBuilder('users', { queryParams: 'name=eq.null' });
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for all data where name is not null', () => {
+      const expectedQuery = 'SELECT * FROM users WHERE name IS NOT NULL;';
+      const query = queryBuilder('users', { queryParams: 'name=neq.null' });
       expect(query).to.equal(expectedQuery);
     });
 
@@ -77,7 +89,7 @@ describe('Test querystring builder', () => {
       expect(query).to.equal(expectedQuery);
     });
 
-    it('Should return a querystring witha select to a sql view with filtering parameters', () => {
+    it('Should return a querystring with a select to a sql view with filtering parameters', () => {
       const expectedQuery = 'SELECT * FROM view_rolemembers WHERE email = \'manager@mail.com\';'
       const query = queryBuilder('view_rolemembers', { queryParams: 'email=eq.manager@mail.com' });
       expect(query).to.equal(expectedQuery);


### PR DESCRIPTION
…Q as a filter to API with matching tests