### PR TITLE
Return inserted data

### DIFF
--- a/app/db/utils.js
+++ b/app/db/utils.js
@@ -35,7 +35,7 @@ function insertIntoStringBuilder(body='') {
   return insertIntoStr;
 }
 
-function queryBuilder(name, { queryParams='', body='', method='' }) {
+function queryBuilder(name, { queryParams='', body='', method='', prefer='' }) {
   let args = '';
   let query ='';
 
@@ -43,7 +43,8 @@ function queryBuilder(name, { queryParams='', body='', method='' }) {
     query = `SELECT * FROM ${name}`;
   } else if (body && method === 'POST') {
     columnsAndValues = insertIntoStringBuilder(body);
-    query = `INSERT INTO ${name} ${columnsAndValues}`;
+    const returning = prefer ? '%20RETURNING *' : '';
+    query = `INSERT INTO ${name} ${columnsAndValues}${returning}`;
   } else if (body && !queryParams) {
     args = viewFunctionArgsBuilder(body);
     query = `SELECT * FROM ${name}${args}`;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -90,7 +90,8 @@ app.post('/v1/:name', (req, res) => {
   const { body } = req;
   const { dbrole } = res.locals.user;
   const { name } = req.params;
-  const queryString = queryBuilder(name, { body, method: req.method });
+  const { prefer } = req.headers;
+  const queryString = queryBuilder(name, { body, method: req.method, prefer });
 
   const data = query(dbrole, name, queryString);
   Promise.all([data])

--- a/test/db/utils.test.js
+++ b/test/db/utils.test.js
@@ -103,6 +103,14 @@ describe('Test querystring builder', () => {
       const query = queryBuilder('staff', {  body: body, method: 'POST'});
       expect(query).to.equal(expectedQuery);
     });
+
+    it('Should return a querystring with option to return all inserted data', () => {
+      const body = {'name': 'John', 'age': 34, 'email': 'john@mail.com'};
+      const prefer = 'return=representation';
+      const expectedQuery = 'INSERT INTO staff (name,age,email) VALUES (\'John\',\'34\',\'john@mail.com\') RETURNING *;';
+      const query = queryBuilder('staff', {  body: body, method: 'POST', prefer });
+      expect(query).to.equal(expectedQuery);
+    });
   });
 
   describe('DELETE - querystring builder', () => {


### PR DESCRIPTION
On the request header set:
`'Prefer': 'return=representation'`

Since this is the only value we check the code only checks if `request.headers.prefer` exists.
If it does:
`INSERT INTO <table> (cols...) VALUES (vals...) RETURNING *;`
If it doesn't:
`INSERT INTO <table> (cols...) VALUES (vals...);`