### PR TITLE
Add functionality to insert multiple rows into a table

### DIFF
--- a/app/db/utils.js
+++ b/app/db/utils.js
@@ -15,24 +15,45 @@ function viewFunctionArgsBuilder(body = '') {
   return args ? `(${args})` : args;
 }
 
-function insertIntoOptionsBuilder(body) {
+function columnsAndRowsBuilder(data) {
   let columns = '';
   let values = '';
 
-  for (const key in body) {
-    if (Object.prototype.hasOwnProperty.call(body, key)) {
+  for (const key in data) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
       columns += columns ? ',' : '';
       columns += key;
       values += values ? ',' : '';
 
-      if (typeof body[key] === 'object') {
-        values += `'${JSON.stringify(body[key])}'`;
+      if (typeof data[key] === 'object') {
+        values += `'${JSON.stringify(data[key])}'`;
       } else {
-        values += `'${body[key]}'`;
+        values += `'${data[key]}'`;
       }
     }
   }
-  return `(${columns}) VALUES (${values})`;
+  return { columns, values };
+}
+
+function insertIntoOptionsBuilder(body) {
+  let rowValues = '';
+  let columns = '';
+  let values = '';
+
+  if (Array.isArray(body)) {
+    body.map((data) => {
+      const dataObj = columnsAndRowsBuilder(data);
+      rowValues += rowValues ? ',' : '';
+      rowValues += dataObj.values ? `(${dataObj.values})` : '';
+      columns = `(${dataObj.columns})`;
+    });
+
+    return `${columns} VALUES ${rowValues}`;
+  }
+  const dataObj = columnsAndRowsBuilder(body);
+  columns = `(${dataObj.columns})`;
+
+  return `(${dataObj.columns}) VALUES (${dataObj.values})`;
 }
 
 function queryParamsBuilder({ queryParams, body = '', name = '' }) {

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -156,6 +156,31 @@ describe('Test querystring builder', () => {
 
       expect(query).to.equal(expectedQuery);
     });
+
+    it('Should return a querystring with option to insert multiple rows, without returning the data inserted', () => {
+      const name = 'staff';
+      const body = [
+        { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
+        { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
+      ];
+      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com');`;
+      const query = insertIntoQueryBuilder({ name, body });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with option to insert multiple rows, returning the data inserted', () => {
+      const name = 'staff';
+      const body = [
+        { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
+        { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
+      ];
+      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com') RETURNING *;`;
+      const prefer = 'return=representation';
+      const query = insertIntoQueryBuilder({ name, body, prefer });
+
+      expect(query).to.equal(expectedQuery);
+    });
   });
 
   describe('PATCH - querystring builder', () => {


### PR DESCRIPTION
to test using postman

POST:
`http://localhost:5000/v1/<table_name>`

headers (optional) if added returns the data inserted:
```
Prefer: return=representation
```
body:
insert multiple rows (also works if only one object is passed)
```json
[
	{
		"line1": "data",
		"city": "Porto",
		"countryid": "132"  
	},
	{
		"line1": "data",
		"city": "Edinburgh",
		"countryid": "231"
	}
]
```

insert one row
```json
{
	"line1": "data",
	"city": "Porto",
	"countryid": "132"  
}
```