### PR TITLE
Add limit filter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "consistent-return": "off",
     "prefer-destructuring": "off",
     "object-curly-newline": ["error", { "multiline": true }],
+    "no-loop-func": "off",
   },
   "extends": "airbnb/base",
   "env": {

--- a/app/db/utils.js
+++ b/app/db/utils.js
@@ -198,10 +198,6 @@ function selectQueryBuilder({ name, body = '', queryParams = '' }) {
 
 // version2 Creates a SELECT querystring
 function selectQueryBuilderV2({ name, body = '', queryParams = '' }) {
-  if (!body && Object.entries(queryParams).length === 0) {
-    return `SELECT * FROM ${name};`;
-  }
-
   return queryParamsBuilderV2({ name, queryParams });
 }
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -8,6 +8,7 @@ const moment = require('moment');
 const config = require('../config/core');
 const logger = require('../config/logger')(__filename);
 const v1 = require('./v1');
+const v2 = require('./v2');
 
 const app = express();
 const corsConfiguration = {
@@ -58,6 +59,7 @@ app.use((req, res, next) => {
 });
 
 app.use('/v1', v1);
+app.use('/v2', v2);
 app.get('/_health', (req, res) => {
   logger.verbose('API is Alive & Kicking!');
   return res.status(200).json({ 'status': 'UP' });

--- a/app/routes/v2/index.js
+++ b/app/routes/v2/index.js
@@ -1,0 +1,31 @@
+const express = require('express');
+
+// local imports
+const logger = require('../../config/logger')(__filename);
+const query = require('../../db/query');
+const { selectQueryBuilderV2 } = require('../../db/utils');
+
+const app = express();
+
+app.get('/:name', (req, res) => {
+  const { name } = req.params;
+  const { dbrole } = res.locals.user;
+  const queryParams = req.query;
+  const queryString = selectQueryBuilderV2({ name, queryParams });
+
+  if (!queryString) {
+    return res.status(400).json({ 'error': 'Invalid query parameters' });
+  }
+
+  const data = query(dbrole, name, queryString);
+
+  Promise.all([data])
+    .then(resultsArray => res.status(200).json(resultsArray[0]))
+    .catch((error) => {
+      logger.error(error.stack);
+      res.status(400).json({ 'error': error.message });
+    });
+  res.status(400).json({ 'error': queryParams });
+});
+
+module.exports = app;

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -5,11 +5,12 @@ const {
   deleteQueryBuilder,
   insertIntoQueryBuilder,
   selectQueryBuilder,
+  selectQueryBuilderV2,
   updateQueryBuilder,
 } = require('../../../app/db/utils');
 
-describe('Test querystring builder', () => {
-  describe('GET - querystring builder', () => {
+describe('Test database utils', () => {
+  describe('v1 GET - querystring builder', () => {
     it('Should return a querystring with two columns selected', () => {
       const name = 'roles';
       const queryParams = 'select=developer,linemanager';
@@ -137,7 +138,7 @@ describe('Test querystring builder', () => {
     });
   });
 
-  describe('POST - querystring builder', () => {
+  describe('v1 POST - querystring builder', () => {
     it('Should return a querystring to insert values into columns', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
@@ -183,7 +184,7 @@ describe('Test querystring builder', () => {
     });
   });
 
-  describe('PATCH - querystring builder', () => {
+  describe('v1 PATCH - querystring builder', () => {
     it('Should return a querystring to update existing data matching an id', () => {
       const name = 'identity';
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
@@ -230,7 +231,7 @@ describe('Test querystring builder', () => {
     });
   });
 
-  describe('DELETE - querystring builder', () => {
+  describe('v1 DELETE - querystring builder', () => {
     it('Should return a querystring to delete a row matching the email address', () => {
       const name = 'roles';
       const queryParams = 'email=eq.manager@mail.com';
@@ -250,7 +251,7 @@ describe('Test querystring builder', () => {
     });
   });
 
-  describe('POST To View Function - querystring builder', () => {
+  describe('v1 POST To View Function - querystring builder', () => {
     it('Should return a querystring for a function view', () => {
       const name = 'staffdetails';
       const body = { 'argstaffemail': 'daisy@mail.com' };
@@ -287,6 +288,58 @@ describe('Test querystring builder', () => {
       const query = selectQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);
+    });
+  });
+
+  describe('v2 GET - querystring builder', () => {
+    it('Should return a querystring with two columns selected filtered by name and city and a limit of 5 rows', () => {
+      const name = 'roles';
+      const queryParams = {
+        'select': 'name,city',
+        'filter': [
+          'name=eq.Tilbury 1',
+          'city=eq.London',
+        ],
+        'limit': '5',
+      };
+      const expectedQuery = `SELECT name,city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
+      const name = 'roles';
+      const queryParams = {
+        'filter': [
+          'firstname=eq.Pedro',
+        ],
+        'limit': '1',
+      };
+      const expectedQuery = `SELECT * FROM ${name} WHERE firstname = 'Pedro' LIMIT 1;`;
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with all columns and a limit of 1 row', () => {
+      const name = 'roles';
+      const queryParams = { 'limit': '1' };
+      const expectedQuery = `SELECT * FROM ${name} LIMIT 1;`;
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return an empty querystring if there is more than one select in the query params', () => {
+      const name = 'roles';
+      const queryParams = {
+        'limit': ['3', '77'],
+        'select': ['name,age', 'location'],
+      };
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal('');
     });
   });
 });


### PR DESCRIPTION
Implements functionality to `LIMIT` the number of rows being returned by the query.
This functionality is only available for the API version 2.

To use version 2 you need to replace `http://localhost:5000/v1/<table_name>` with `http://localhost:5000/v2/<table_name>`

Tested with:
```
/v2/team?select=name,location&filter=name=eq.Tilbury%201&limit=5&filter=location=eq.London
# SELECT name,location FROM team WHERE name = 'Tilbury 1' AND location = 'London' LIMIT 5;

/v2/team?filter=firstname=eq.Pedro&limit=1
# SELECT * FROM team WHERE firstname = 'Pedro' LIMIT 1; (There can only be one Pedro)

/v2/team?limit=1
# SELECT * FROM team LIMIT 1;
```

If more than one `SELECT` or `LIMIT` is passed in the query parameters the API returns a 400 Bad response, for instance:

```
/v2/team?filter=firstname=eq.Pedro&limit=1&limit=5
# 400 Bad request

/v2/team?select=firstname,lastname&filter=eq.Pedro&limit=1&select=postcode
# 400 Bad request
```
