### PR TITLE
Ensure filter is an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,54 @@ docker rmi quay.io/ukhomeofficedigital/cop-data-api:dev
 
 The API is secured using JWT keycloak tokens. It requires a claim called 'dbrole' to be included in the token.
 The value given for dbrole will enable the API to switch to the correct role within the database.
+
+## Filtering examples
+Return columns name and age filtering user names matching 'John' and 'Rachel'
+```bash
+select=name,age&filter=name=in.(John, Rachel)
+```
+
+Return columns nationality with a limit of 3 rows
+```bash
+select=nationality&limit=3
+```
+
+Return all users where names match 'John' and 'Debbie'
+```bash
+filter=name=in.(John, Debbie)
+```
+
+Return all countries where names match 'Denmark', and 'Portugal'
+```bash
+filter=name=in.(Denmark, Portugal)
+```
+
+Return all users where name matches 'John'
+```bash
+filter=name=eq.John
+```
+
+Return all users where name is not equal to 'John'
+```bash
+filter=name=neq.John
+```
+
+Return user where name is 'John' and email is 'john@mail.com'
+```bash
+filter=name=eq.John&filter=email=eq.john@mail.com
+```
+
+Return only the entity schema
+```bash
+mode=schemaOnly
+```
+
+Return only the entity data
+```bash
+mode=dataOnly
+```
+
+Return only the entity data where user name matches 'John'
+```bash
+mode=dataOnly&filter=name=eq.John
+```

--- a/app/routes/v2/index.js
+++ b/app/routes/v2/index.js
@@ -11,6 +11,11 @@ app.get('/:name', (req, res) => {
   const { name } = req.params;
   const { dbrole } = res.locals.user;
   const queryParams = req.query;
+
+  if (queryParams.filter && !Array.isArray(queryParams.filter)) {
+    queryParams.filter = [queryParams.filter];
+  }
+
   const queryString = selectQueryBuilderV2({ name, queryParams });
 
   if (!queryString) {


### PR DESCRIPTION
Express `req.query` only puts in an array if a field is used twice, example:
```
filter=name=eq.Pedro&filter=name=eq.Mark
# filter: ['Pedro', 'Mark']
```
however if you only filter by one name, e.g:
```
filter=name=eq.Mark
# filter: 'Mark'
```
filter is passed as a string, ideally we want to be consistent and always have the contents of `filter` being inside of an array so that it uses the same code throughout.

Updates README with some examples on how to use queries while a more formal documentation is not written.