### PR TITLE
Adds a Slack notification to the build pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -171,3 +171,21 @@ pipeline:
       event: deployment
       environment: production
       branch: master
+
+  notify:
+    image: plugins/slack
+    secrets: [ SLACK_WEBHOOK ]
+    channel: cop-deployments
+    username: Drone Build Watcher
+    template: >
+        {{#success build.status}}
+          *{{repo.name}} - Build {{build.number}} succeeded*
+          {{build.link}}
+        {{else}}
+          *{{repo.name}} - Build {{build.number}} failed*
+          {{build.link}}
+        {{/success}}
+    when:
+      branch: master
+      event: [ push, deployment ]
+      status: [ success, failure ]


### PR DESCRIPTION
Adds a build step at the end of the drone pipeline to publish a notification to a Slack channel showing the build status (and author)