### PR TITLE
Parameterised queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ typings/
 .dynamodb/
 
 .DS_Store
+*.swp

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -10,6 +10,14 @@ class QueryFilter {
   }
 }
 
+/*
+ * Query Types
+ */
+const SELECT_QUERY = 'SELECT';
+const INSERT_QUERY = 'INSERT';
+const UPDATE_QUERY = 'UPDATE';
+
+
 class AbstractSyntaxTree {
   constructor(type, objectName, objectType) {
     if (!type || !objectName || !objectType) {
@@ -54,15 +62,11 @@ class AbstractSyntaxTree {
   }
 
   returnData() {
-    this.returning = true;
+    if (this.type === UPDATE_QUERY || this.type === INSERT_QUERY) {
+      this.returning = true;
+    }
   }
 }
-
-/*
- * Query Types
- */
-const SELECT_QUERY = 'SELECT';
-const INSERT_QUERY = 'INSERT';
 
 /*
  * Object Types
@@ -86,6 +90,7 @@ module.exports = {
   AbstractSyntaxTree,
   INSERT_QUERY,
   SELECT_QUERY,
+  UPDATE_QUERY,
   TABLE,
   OP_EQUALS,
   OP_GT,

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -94,6 +94,12 @@ class AbstractSyntaxTree {
     }
     this.rowCount = limit;
   }
+
+  nextParameter(value) {
+    this.parameters.push(value);
+    this.parameterCount = this.parameterCount + 1;
+    return this.parameterCount;
+  }
 }
 /*
  * Filter operators

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -22,12 +22,15 @@ class AbstractSyntaxTree {
     this.columns = [];
     this.data = [];
     this.filter = [];
-    this.returning = [];
+    this.returning = false;
   }
 
   addColumns(columns) {
     if (!columns) {
       throw new TypeError("Can't add a null or undefined column");
+    }
+    if (this.data.length > 0) {
+      throw new TypeError("Can't add columns once data hase been added");
     }
     if (!Array.isArray(columns)) {
       this.columns.push(columns);
@@ -39,12 +42,27 @@ class AbstractSyntaxTree {
   addFilter(fieldName, operator, operand) {
     this.filter.push(new QueryFilter(fieldName, operator, operand));
   }
+
+  addRow(data) {
+    if (!data) {
+      throw new TypeError("Can't add a null row of data");
+    }
+    const row = [];
+
+    this.columns.forEach(c => row.push(data[c] || null));
+    this.data.push(row);
+  }
+
+  returnData() {
+    this.returning = true;
+  }
 }
 
 /*
  * Query Types
  */
 const SELECT_QUERY = 'SELECT';
+const INSERT_QUERY = 'INSERT';
 
 /*
  * Object Types
@@ -66,6 +84,7 @@ const NULL = 'NULL';
 
 module.exports = {
   AbstractSyntaxTree,
+  INSERT_QUERY,
   SELECT_QUERY,
   TABLE,
   OP_EQUALS,

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -16,6 +16,7 @@ class QueryFilter {
 const SELECT_QUERY = 'SELECT';
 const INSERT_QUERY = 'INSERT';
 const UPDATE_QUERY = 'UPDATE';
+const DELETE_QUERY = 'DELETE';
 
 
 class AbstractSyntaxTree {
@@ -88,6 +89,7 @@ const NULL = 'NULL';
 
 module.exports = {
   AbstractSyntaxTree,
+  DELETE_QUERY,
   INSERT_QUERY,
   SELECT_QUERY,
   UPDATE_QUERY,

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -24,6 +24,7 @@ const DELETE_QUERY = 'DELETE';
 const TABLE = 'TABLE';
 const FUNCTION = 'FUNCTION';
 
+
 class AbstractSyntaxTree {
   constructor(type, objectName, objectType) {
     if (!type || !objectName || !objectType) {
@@ -37,6 +38,7 @@ class AbstractSyntaxTree {
     this.data = [];
     this.filter = [];
     this.arguments = [];
+    this.rowCount = 0;
     this.returning = false;
   }
 
@@ -80,6 +82,13 @@ class AbstractSyntaxTree {
     if (this.type === UPDATE_QUERY || this.type === INSERT_QUERY) {
       this.returning = true;
     }
+  }
+
+  limit(limit) {
+    if (limit && limit <= 0) {
+      throw new TypeError(`Limit must be a positive integer: '${limit}'`);
+    }
+    this.rowCount = limit;
   }
 }
 /*

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -18,6 +18,11 @@ const INSERT_QUERY = 'INSERT';
 const UPDATE_QUERY = 'UPDATE';
 const DELETE_QUERY = 'DELETE';
 
+/*
+ * Object Types
+ */
+const TABLE = 'TABLE';
+const FUNCTION = 'FUNCTION';
 
 class AbstractSyntaxTree {
   constructor(type, objectName, objectType) {
@@ -31,6 +36,7 @@ class AbstractSyntaxTree {
     this.columns = [];
     this.data = [];
     this.filter = [];
+    this.arguments = [];
     this.returning = false;
   }
 
@@ -62,18 +68,20 @@ class AbstractSyntaxTree {
     this.data.push(row);
   }
 
+  addArguments(args) {
+    if (this.objectType !== FUNCTION) {
+      throw new TypeError(`Can only use arguments with FUNCTION objects. Object type is ${this.objectType}`);
+    }
+
+    this.arguments = Object.entries(args);
+  }
+
   returnData() {
     if (this.type === UPDATE_QUERY || this.type === INSERT_QUERY) {
       this.returning = true;
     }
   }
 }
-
-/*
- * Object Types
- */
-const TABLE = 'TABLE';
-
 /*
  * Filter operators
  */
@@ -93,6 +101,7 @@ module.exports = {
   INSERT_QUERY,
   SELECT_QUERY,
   UPDATE_QUERY,
+  FUNCTION,
   TABLE,
   OP_EQUALS,
   OP_GT,

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -1,0 +1,79 @@
+
+class QueryFilter {
+  constructor(fieldName, operator, operand) {
+    if (!fieldName || !operator || !operand) {
+      throw new TypeError(`Cannot construct QueryFilter without specifying "fieldName" (${fieldName}), "operator"(${operator})  and "operand" (${operand})`);
+    }
+    this.fieldName = fieldName;
+    this.operator = operator;
+    this.operand = operand;
+  }
+}
+
+class AbstractSyntaxTree {
+  constructor(type, objectName, objectType) {
+    if (!type || !objectName || !objectType) {
+      throw new TypeError(`Cannot construct AST without specifying "type" (${type}), "objectName"(${objectName})  and "objectType" (${objectType})`);
+    }
+
+    this.type = type;
+    this.objectName = objectName;
+    this.objectType = objectType;
+    this.columns = [];
+    this.data = [];
+    this.filter = [];
+    this.returning = [];
+  }
+
+  addColumns(columns) {
+    if (!columns) {
+      throw new TypeError("Can't add a null or undefined column");
+    }
+    if (!Array.isArray(columns)) {
+      this.columns.push(columns);
+    } else {
+      this.columns.push(...columns.filter(c => c));
+    }
+  }
+
+  addFilter(fieldName, operator, operand) {
+    this.filter.push(new QueryFilter(fieldName, operator, operand));
+  }
+}
+
+/*
+ * Query Types
+ */
+const SELECT_QUERY = 'SELECT';
+
+/*
+ * Object Types
+ */
+const TABLE = 'TABLE';
+
+/*
+ * Filter operators
+ */
+const OP_EQUALS = 'EQ';
+const OP_GT = 'GT';
+const OP_GTE = 'GTE';
+const OP_IN = 'IN';
+const OP_IS = 'IS';
+const OP_LT = 'LT';
+const OP_LTE = 'LTE';
+
+const NULL = 'NULL';
+
+module.exports = {
+  AbstractSyntaxTree,
+  SELECT_QUERY,
+  TABLE,
+  OP_EQUALS,
+  OP_GT,
+  OP_GTE,
+  OP_IN,
+  OP_IS,
+  OP_LT,
+  OP_LTE,
+  NULL,
+};

--- a/app/db/ast.js
+++ b/app/db/ast.js
@@ -40,6 +40,10 @@ class AbstractSyntaxTree {
     this.arguments = [];
     this.rowCount = 0;
     this.returning = false;
+
+    // Working storage used during code generation
+    this.parameters = [];
+    this.parameterCount = 0;
   }
 
   addColumns(columns) {

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -15,7 +15,9 @@ const {
 
 const arrayToString = array => (Array.isArray(array) ? JSON.stringify(array) : array);
 
-const generateTuple = tuple => `('${tuple.map(arrayToString).join("', '")}')`;
+const generateTuple = (tuple, ast) => `(${tuple.map(arrayToString)
+  .map(value => `$${ast.nextParameter(value)}`)
+  .join(', ')})`;
 
 const quoteStringParam = param => (isNaN(param) ? `'${param}'` : param);
 const quoteNonArrayParam = param => (!Array.isArray(param) ? `'${param}'` : param);
@@ -29,7 +31,7 @@ const generateValues = (ast) => {
   if (ast.data.length === 0) {
     throw new TypeError('Must have at least one data row for insert');
   }
-  const values = ast.data.map(generateTuple);
+  const values = ast.data.map(row => generateTuple(row, ast));
 
   return `VALUES ${values.join(', ')}`;
 };
@@ -59,7 +61,7 @@ const generateWhere = (ast) => {
       case OP_GTE:
         return `${filter.fieldName} >= ${quoteStringParam(filter.operand)}`;
       case OP_IN:
-        return `${filter.fieldName} IN ${generateTuple((filter.operand))}`;
+        return `${filter.fieldName} IN ${generateTuple(filter.operand, ast)}`;
       case OP_IS:
         return `${filter.fieldName} IS ${filter.operand}`;
       case OP_LT:

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -23,6 +23,7 @@ const quoteNonArrayParam = param => (!Array.isArray(param) ? `'${param}'` : para
 const generateColumns = ast => ast.columns.join(', ');
 
 const generateArgs = ast => ast.arguments.map(([name, value]) => `${name}=>'${value}'`).join(', ');
+const generateLimit = ast => (ast.rowCount ? ` LIMIT ${ast.rowCount}` : '');
 
 const generateValues = (ast) => {
   if (ast.data.length === 0) {
@@ -79,8 +80,9 @@ const generateWhere = (ast) => {
 const generateSelect = (ast) => {
   const selectClause = generateColumns(ast) || '*';
   const whereClause = generateWhere(ast);
+  const limit = generateLimit(ast);
 
-  return `SELECT ${selectClause} FROM ${ast.objectName}${whereClause};`;
+  return `SELECT ${selectClause} FROM ${ast.objectName}${whereClause}${limit};`;
 };
 
 const generateInsert = (ast) => {
@@ -109,9 +111,10 @@ const generateDelete = (ast) => {
 const generateFunctionCall = (ast) => {
   const selectClause = generateColumns(ast) || '*';
   const whereClause = generateWhere(ast);
+  const limit = generateLimit(ast);
   const args = generateArgs(ast);
 
-  return `SELECT ${selectClause} FROM ${ast.objectName}(${args})${whereClause};`;
+  return `SELECT ${selectClause} FROM ${ast.objectName}(${args})${whereClause}${limit};`;
 };
 
 const generateCode = (ast) => {

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -21,7 +21,7 @@ const generateTuple = (tuple, ast) => `(${tuple.map(arrayToString)
 
 const generateColumns = ast => ast.columns.join(', ');
 
-const generateArgs = ast => ast.arguments.map(([name, value]) => `${name}=>'${value}'`).join(', ');
+const generateArgs = ast => ast.arguments.map(([name, value]) => `${name}=>$${ast.nextParameter(value)}`).join(', ');
 const generateLimit = ast => (ast.rowCount ? ` LIMIT ${ast.rowCount}` : '');
 
 const generateValues = (ast) => {
@@ -128,9 +128,9 @@ const generateDelete = (ast) => {
 
 const generateFunctionCall = (ast) => {
   const selectClause = generateColumns(ast) || '*';
+  const args = generateArgs(ast);
   const whereClause = generateWhere(ast);
   const limit = generateLimit(ast);
-  const args = generateArgs(ast);
 
   const query = `SELECT ${selectClause} FROM ${ast.objectName}(${args})${whereClause}${limit};`;
 

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -1,4 +1,5 @@
 const {
+  DELETE_QUERY,
   INSERT_QUERY,
   SELECT_QUERY,
   UPDATE_QUERY,
@@ -96,6 +97,12 @@ const generateUpdate = (ast) => {
   return `UPDATE ${ast.objectName} SET ${fieldsToUpdate}${whereClause}${returning};`;
 };
 
+const generateDelete = (ast) => {
+  const whereClause = generateWhere(ast);
+
+  return `DELETE FROM ${ast.objectName}${whereClause};`;
+};
+
 const generateCode = (ast) => {
   switch (ast.type) {
     case SELECT_QUERY:
@@ -104,6 +111,8 @@ const generateCode = (ast) => {
       return generateInsert(ast);
     case UPDATE_QUERY:
       return generateUpdate(ast);
+    case DELETE_QUERY:
+      return generateDelete(ast);
     default:
       throw new TypeError(`Query type ${ast.type} not yet supported`);
   }

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -13,11 +13,7 @@ const {
   TABLE,
 } = require('./ast');
 
-const arrayToString = array => (Array.isArray(array) ? JSON.stringify(array) : array);
-
-const generateTuple = (tuple, ast) => `(${tuple.map(arrayToString)
-  .map(value => `$${ast.nextParameter(value)}`)
-  .join(', ')})`;
+const generateTuple = (tuple, ast) => `(${tuple.map(value => `$${ast.nextParameter(value)}`).join(', ')})`;
 
 const generateColumns = ast => ast.columns.join(', ');
 
@@ -42,7 +38,7 @@ const generateFieldsToUpdate = (ast) => {
   }
 
   const data = ast.data[0];
-  return data.map((e, i) => [ast.columns[i], arrayToString(e)])
+  return data.map((e, i) => [ast.columns[i], e])
     .map(([name, value]) => `${name}=$${ast.nextParameter(value)}`)
     .join(', ');
 };

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -19,8 +19,6 @@ const generateTuple = (tuple, ast) => `(${tuple.map(arrayToString)
   .map(value => `$${ast.nextParameter(value)}`)
   .join(', ')})`;
 
-const quoteStringParam = param => (isNaN(param) ? `'${param}'` : param);
-
 const generateColumns = ast => ast.columns.join(', ');
 
 const generateArgs = ast => ast.arguments.map(([name, value]) => `${name}=>'${value}'`).join(', ');
@@ -53,19 +51,19 @@ const generateWhere = (ast) => {
   const filters = ast.filter.map((filter) => {
     switch (filter.operator) {
       case OP_EQUALS:
-        return `${filter.fieldName} = ${quoteStringParam(filter.operand)}`;
+        return `${filter.fieldName} = $${ast.nextParameter(filter.operand)}`;
       case OP_GT:
-        return `${filter.fieldName} > ${quoteStringParam(filter.operand)}`;
+        return `${filter.fieldName} > $${ast.nextParameter(filter.operand)}`;
       case OP_GTE:
-        return `${filter.fieldName} >= ${quoteStringParam(filter.operand)}`;
+        return `${filter.fieldName} >= $${ast.nextParameter(filter.operand)}`;
       case OP_IN:
         return `${filter.fieldName} IN ${generateTuple(filter.operand, ast)}`;
       case OP_IS:
         return `${filter.fieldName} IS ${filter.operand}`;
       case OP_LT:
-        return `${filter.fieldName} < ${quoteStringParam(filter.operand)}`;
+        return `${filter.fieldName} < $${ast.nextParameter(filter.operand)}`;
       case OP_LTE:
-        return `${filter.fieldName} <= ${quoteStringParam(filter.operand)}`;
+        return `${filter.fieldName} <= $${ast.nextParameter(filter.operand)}`;
       default:
         throw new TypeError(`Unimplmented operator ${filter.operator}`);
     }

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -82,7 +82,12 @@ const generateSelect = (ast) => {
   const whereClause = generateWhere(ast);
   const limit = generateLimit(ast);
 
-  return `SELECT ${selectClause} FROM ${ast.objectName}${whereClause}${limit};`;
+  const query = `SELECT ${selectClause} FROM ${ast.objectName}${whereClause}${limit};`;
+
+  return {
+    query,
+    'parameters': ast.parameters,
+  };
 };
 
 const generateInsert = (ast) => {
@@ -91,7 +96,12 @@ const generateInsert = (ast) => {
   const values = generateValues(ast);
   const returning = ast.returning ? ' RETURNING *' : '';
 
-  return `INSERT INTO ${ast.objectName} ${columns} ${values}${returning};`;
+  const query = `INSERT INTO ${ast.objectName} ${columns} ${values}${returning};`;
+
+  return {
+    query,
+    'parameters': ast.parameters,
+  };
 };
 
 const generateUpdate = (ast) => {
@@ -99,13 +109,23 @@ const generateUpdate = (ast) => {
   const whereClause = generateWhere(ast);
   const returning = ast.returning ? ' RETURNING *' : '';
 
-  return `UPDATE ${ast.objectName} SET ${fieldsToUpdate}${whereClause}${returning};`;
+  const query = `UPDATE ${ast.objectName} SET ${fieldsToUpdate}${whereClause}${returning};`;
+
+  return {
+    query,
+    'parameters': ast.parameters,
+  };
 };
 
 const generateDelete = (ast) => {
   const whereClause = generateWhere(ast);
 
-  return `DELETE FROM ${ast.objectName}${whereClause};`;
+  const query = `DELETE FROM ${ast.objectName}${whereClause};`;
+
+  return {
+    query,
+    'parameters': ast.parameters,
+  };
 };
 
 const generateFunctionCall = (ast) => {
@@ -114,7 +134,12 @@ const generateFunctionCall = (ast) => {
   const limit = generateLimit(ast);
   const args = generateArgs(ast);
 
-  return `SELECT ${selectClause} FROM ${ast.objectName}(${args})${whereClause}${limit};`;
+  const query = `SELECT ${selectClause} FROM ${ast.objectName}(${args})${whereClause}${limit};`;
+
+  return {
+    query,
+    'parameters': ast.parameters,
+  };
 };
 
 const generateCode = (ast) => {

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -20,7 +20,6 @@ const generateTuple = (tuple, ast) => `(${tuple.map(arrayToString)
   .join(', ')})`;
 
 const quoteStringParam = param => (isNaN(param) ? `'${param}'` : param);
-const quoteNonArrayParam = param => (!Array.isArray(param) ? `'${param}'` : param);
 
 const generateColumns = ast => ast.columns.join(', ');
 
@@ -45,9 +44,8 @@ const generateFieldsToUpdate = (ast) => {
   }
 
   const data = ast.data[0];
-  return data.map(quoteNonArrayParam)
-    .map((e, i) => [ast.columns[i], arrayToString(e)])
-    .map(([name, value]) => `${name}=${value}`)
+  return data.map((e, i) => [ast.columns[i], arrayToString(e)])
+    .map(([name, value]) => `${name}=$${ast.nextParameter(value)}`)
     .join(', ');
 };
 

--- a/app/db/codegen.js
+++ b/app/db/codegen.js
@@ -1,0 +1,62 @@
+const {
+  SELECT_QUERY,
+  OP_EQUALS,
+  OP_GT,
+  OP_GTE,
+  OP_IN,
+  OP_LT,
+  OP_LTE,
+  OP_IS,
+} = require('./ast');
+
+const generateTuple = tuple => `('${tuple.join("', '")}')`;
+
+const quoteStringParam = param => (isNaN(param) ? `'${param}'` : param);
+
+const generateColumns = ast => ast.columns.join(', ');
+
+const generateWhere = (ast) => {
+  const filters = ast.filter.map((filter) => {
+    switch (filter.operator) {
+      case OP_EQUALS:
+        return `${filter.fieldName} = ${quoteStringParam(filter.operand)}`;
+      case OP_GT:
+        return `${filter.fieldName} > ${quoteStringParam(filter.operand)}`;
+      case OP_GTE:
+        return `${filter.fieldName} >= ${quoteStringParam(filter.operand)}`;
+      case OP_IN:
+        return `${filter.fieldName} IN ${generateTuple((filter.operand))}`;
+      case OP_IS:
+        return `${filter.fieldName} IS ${filter.operand}`;
+      case OP_LT:
+        return `${filter.fieldName} < ${quoteStringParam(filter.operand)}`;
+      case OP_LTE:
+        return `${filter.fieldName} <= ${quoteStringParam(filter.operand)}`;
+      default:
+        throw new TypeError(`Unimplmented operator ${filter.operator}`);
+    }
+  });
+
+  if (filters.length !== 0) {
+    return ` WHERE ${filters.join(' AND ')}`;
+  }
+  return '';
+};
+
+const generateSelect = (ast) => {
+  const selectClause = generateColumns(ast) || '*';
+  const whereClause = generateWhere(ast);
+
+  return `SELECT ${selectClause} FROM ${ast.objectName}${whereClause};`;
+};
+
+const generateCode = (ast) => {
+  switch (ast.type) {
+    case SELECT_QUERY:
+      return generateSelect(ast);
+    default:
+      throw new TypeError(`Query type ${ast.type} not yet supported`);
+  }
+};
+
+module.exports = { generateCode };

--- a/app/db/query.js
+++ b/app/db/query.js
@@ -5,8 +5,8 @@ const pool = require('./index');
 const query = (role, name, queryString) => new Promise((resolve, reject) => {
   pool.query(`SET ROLE ${role};`)
     .then(() => {
-      logger.info(`Running query ${queryString}`);
-      return pool.query(`${queryString}`);
+      logger.info(`Running query ${queryString.query}`);
+      return pool.query(queryString.query, queryString.parameters);
     })
     .then(data => resolve(data.rows))
     .catch((error) => {

--- a/app/db/utils.js
+++ b/app/db/utils.js
@@ -30,6 +30,14 @@ function insertIntoOptionsBuilder(body, ast) {
   }
 }
 
+function scalarFilter(ast, field, operator, operand) {
+  operand = operand.replace(',', '');
+  if (!isNaN(operand)) {
+    operand = Number(operand);
+  }
+  ast.addFilter(field, operator, operand);
+}
+
 function queryParamsBuilder({ queryParams }, ast) {
   queryParams = queryParams.split('&');
   queryParams.map((params) => {
@@ -44,7 +52,7 @@ function queryParamsBuilder({ queryParams }, ast) {
       ast.addColumns(paramValue.split(','));
     } else {
       const field = paramName;
-      let [filter = '', value = ''] = paramValue.split(/\.(.+)/);
+      let [filter = '', value = ''] = paramValue.split(/\.(.+),*$/);
 
       if (value === 'null') {
         if (filter !== 'eq') {
@@ -57,24 +65,19 @@ function queryParamsBuilder({ queryParams }, ast) {
 
       switch (filter) {
         case 'gt':
-          value = value.replace(',', '');
-          ast.addFilter(field, OP_GT, value);
+          scalarFilter(ast, field, OP_GT, value);
           break;
         case 'gte':
-          value = value.replace(',', '');
-          ast.addFilter(field, OP_GTE, value);
+          scalarFilter(ast, field, OP_GTE, value);
           break;
         case 'lt':
-          value = value.replace(',', '');
-          ast.addFilter(field, OP_LT, value);
+          scalarFilter(ast, field, OP_LT, value);
           break;
         case 'lte':
-          value = value.replace(',', '');
-          ast.addFilter(field, OP_LTE, value);
+          scalarFilter(ast, field, OP_LTE, value);
           break;
         case 'eq':
-          value = value.replace(',', '');
-          ast.addFilter(field, OP_EQUALS, value);
+          scalarFilter(ast, field, OP_EQUALS, value);
           break;
         case 'in':
           value = value.replace('(', '').replace(')', '');

--- a/app/routes/v1/index.js
+++ b/app/routes/v1/index.js
@@ -5,6 +5,7 @@ const logger = require('../../config/logger')(__filename);
 const query = require('../../db/query');
 const {
   deleteQueryBuilder,
+  functionQueryBuilder,
   insertIntoQueryBuilder,
   selectQueryBuilder,
   updateQueryBuilder,
@@ -16,20 +17,25 @@ app.get('/:name', (req, res) => {
   const { name } = req.params;
   const { dbrole } = res.locals.user;
   const queryParams = req.url.split('?')[1];
-  const queryString = selectQueryBuilder({ name, queryParams });
+  try {
+    const queryString = selectQueryBuilder({ name, queryParams });
 
-  if (!queryString) {
+    if (!queryString) {
+      return res.status(400).json({ 'error': 'Invalid query parameters' });
+    }
+
+    const data = query(dbrole, name, queryString);
+
+    Promise.all([data])
+      .then(resultsArray => res.status(200).json(resultsArray[0]))
+      .catch((error) => {
+        logger.error(`Error executing request ${error.message}`, error);
+        res.status(400).json({ 'error': error.message });
+      });
+  } catch (error) {
+    logger.error(`Error parsing request ${error.message}`, error);
     return res.status(400).json({ 'error': 'Invalid query parameters' });
   }
-
-  const data = query(dbrole, name, queryString);
-
-  Promise.all([data])
-    .then(resultsArray => res.status(200).json(resultsArray[0]))
-    .catch((error) => {
-      logger.error(error.stack);
-      res.status(400).json({ 'error': error.message });
-    });
 });
 
 app.post('/:name', (req, res) => {
@@ -42,15 +48,20 @@ app.post('/:name', (req, res) => {
     return res.status(400).json({ 'error': 'Invalid post request' });
   }
 
-  const queryString = insertIntoQueryBuilder({ name, body, prefer });
-  const data = query(dbrole, name, queryString);
+  try {
+    const queryString = insertIntoQueryBuilder({ name, body, prefer });
+    const data = query(dbrole, name, queryString);
 
-  Promise.all([data])
-    .then(resultsArray => res.status(200).json(resultsArray[0]))
-    .catch((error) => {
-      logger.error(error.stack);
-      res.status(400).json({ 'error': error.message });
-    });
+    Promise.all([data])
+      .then(resultsArray => res.status(200).json(resultsArray[0]))
+      .catch((error) => {
+        logger.error(`Error executing request ${error.message}`, error);
+        res.status(400).json({ 'error': error.message });
+      });
+  } catch (error) {
+    logger.error(`Error parsing request ${error.message}`, error);
+    return res.status(400).json({ 'error': 'Invalid query parameters' });
+  }
 });
 
 app.patch('/:name/:id?', (req, res) => {
@@ -63,16 +74,20 @@ app.patch('/:name/:id?', (req, res) => {
   if (Object.entries(body).length === 0 && (!id || !queryParams)) {
     return res.status(400).json({ 'error': 'Invalid patch request' });
   }
+  try {
+    const queryString = updateQueryBuilder({ name, body, id, queryParams, prefer });
+    const data = query(dbrole, name, queryString);
 
-  const queryString = updateQueryBuilder({ name, body, id, queryParams, prefer });
-  const data = query(dbrole, name, queryString);
-
-  Promise.all([data])
-    .then(resultsArray => res.status(200).json(resultsArray[0]))
-    .catch((error) => {
-      logger.error(error.stack);
-      res.status(400).json({ 'error': error.message });
-    });
+    Promise.all([data])
+      .then(resultsArray => res.status(200).json(resultsArray[0]))
+      .catch((error) => {
+        logger.error(`Error executing request ${error.message}`, error);
+        res.status(400).json({ 'error': error.message });
+      });
+  } catch (error) {
+    logger.error(`Error parsing request ${error.message}`, error);
+    return res.status(400).json({ 'error': 'Invalid query parameters' });
+  }
 });
 
 app.delete('/:name', (req, res) => {
@@ -84,15 +99,20 @@ app.delete('/:name', (req, res) => {
     return res.status(400).json({ 'error': 'Invalid query parameters' });
   }
 
-  const queryString = deleteQueryBuilder({ name, queryParams });
-  const data = query(dbrole, name, queryString);
+  try {
+    const queryString = deleteQueryBuilder({ name, queryParams });
+    const data = query(dbrole, name, queryString);
 
-  Promise.all([data])
-    .then(resultsArray => res.status(200).json(resultsArray[0]))
-    .catch((error) => {
-      logger.error(error.stack);
-      res.status(400).json({ 'error': error.message });
-    });
+    Promise.all([data])
+      .then(resultsArray => res.status(200).json(resultsArray[0]))
+      .catch((error) => {
+        logger.error(`Error executing request ${error.message}`, error);
+        res.status(400).json({ 'error': error.message });
+      });
+  } catch (error) {
+    logger.error(`Error parsing request ${error.message}`, error);
+    return res.status(400).json({ 'error': 'Invalid query parameters' });
+  }
 });
 
 app.post('/rpc/:name', (req, res) => {
@@ -100,19 +120,24 @@ app.post('/rpc/:name', (req, res) => {
   const { dbrole } = res.locals.user;
   const { name } = req.params;
   const queryParams = req.url.split('?')[1];
-  const queryString = selectQueryBuilder({ name, queryParams, body });
+  try {
+    const queryString = functionQueryBuilder({ name, queryParams, body });
 
-  if (!queryString) {
+    if (!queryString) {
+      return res.status(400).json({ 'error': 'Invalid query parameters' });
+    }
+
+    const data = query(dbrole, name, queryString);
+    Promise.all([data])
+      .then(resultsArray => res.status(200).json(resultsArray[0]))
+      .catch((error) => {
+        logger.error(`Error executing request ${error.message}`, error);
+        res.status(400).json({ 'error': error.message });
+      });
+  } catch (error) {
+    logger.error(`Error parsing request ${error.message}`, error);
     return res.status(400).json({ 'error': 'Invalid query parameters' });
   }
-
-  const data = query(dbrole, name, queryString);
-  Promise.all([data])
-    .then(resultsArray => res.status(200).json(resultsArray[0]))
-    .catch((error) => {
-      logger.error(error.stack);
-      res.status(400).json({ 'error': error.message });
-    });
 });
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app/server.js",
   "scripts": {
     "coverage": "nyc --reporter html --reporter text npm test",
-    "lint": "eslint -f table",
+    "lint": "eslint -f unix",
     "start": "nodemon app/server.js",
     "test": "NODE_ENV=testing mocha --recursive --exit"
   },

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -373,11 +373,13 @@ describe('Test database utils', () => {
       const body = { 'argstaffemail': 'daisy@mail.com' };
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, FUNCTION);
       ast.addArguments(body);
-      const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>'daisy@mail.com');`;
+      const expectedParams = ['daisy@mail.com'];
+      const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>$1);`;
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for a function view with multiple arguments', () => {
@@ -385,11 +387,13 @@ describe('Test database utils', () => {
       const body = { 'argfirstname': 'Andy', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, FUNCTION);
       ast.addArguments(body);
-      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const expectedParams = ['Andy', 'af4601db-1640-4ff2-a4cc-da44bce99226'];
+      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>$1, argstaffid=>$2);`;
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for a function view with multiple arguments and selected columns', () => {
@@ -399,10 +403,12 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, FUNCTION);
       ast.addColumns('email');
       ast.addArguments(body);
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>$1, argstaffid=>$2);`;
+      const expectedParams = ['Lauren', 'af4601db-1640-4ff2-a4cc-da44bce99226'];
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for a function view with multiple arguments selected columns and filtering parameters', () => {
@@ -412,8 +418,8 @@ describe('Test database utils', () => {
       ast.addColumns('email');
       ast.addFilter('lastname', OP_EQUALS, 'Smith');
       ast.addArguments(body);
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = $1;`;
-      const expectedParams = ['Smith'];
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>$1, argstaffid=>$2) WHERE lastname = $3;`;
+      const expectedParams = ['John', 'af4601db-1640-4ff2-a4cc-da44bce99226', 'Smith'];
 
       const { query, parameters } = generateCode(ast);
 

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -73,11 +73,13 @@ describe('Test database utils', () => {
       const name = 'team';
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
       ast.addFilter('name', OP_EQUALS, 'Tilbury 2');
-      const expectedQuery = `SELECT * FROM ${name} WHERE name = 'Tilbury 2';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE name = $1;`;
+      const expectedParams = ['Tilbury 2'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     xit('Should return a querystring for all data where email matches user email', () => {
@@ -133,11 +135,13 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
       ast.addFilter('id', OP_EQUALS, 3);
       ast.addFilter('continent', OP_EQUALS, 'Asia');
-      const expectedQuery = `SELECT * FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE id = $1 AND continent = $2;`;
+      const expectedParams = [3, 'Asia'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with name, id and continent selected where id and continent match the provided values', () => {
@@ -146,11 +150,13 @@ describe('Test database utils', () => {
       ast.addColumns(['name', 'id', 'continent']);
       ast.addFilter('id', OP_EQUALS, 3);
       ast.addFilter('continent', OP_EQUALS, 'Asia');
-      const expectedQuery = `SELECT name, id, continent FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
+      const expectedQuery = `SELECT name, id, continent FROM ${name} WHERE id = $1 AND continent = $2;`;
+      const expectedParams = [3, 'Asia'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     xit('Should return a querystring witha select to a sql view with filtering parameters', () => {
@@ -167,11 +173,13 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
       ast.addFilter('shiftstartdatetime', OP_GTE, '2019-06-20T12:00:00');
       ast.addFilter('shiftstartdatetime', OP_LT, '2019-06-22T12:00:00');
-      const expectedQuery = `SELECT * FROM ${name} WHERE shiftstartdatetime >= '2019-06-20T12:00:00' AND shiftstartdatetime < '2019-06-22T12:00:00';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE shiftstartdatetime >= $1 AND shiftstartdatetime < $2;`;
+      const expectedParams = ['2019-06-20T12:00:00', '2019-06-22T12:00:00'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with name selected where shiftstartdatetime matches the date range values', () => {
@@ -181,11 +189,13 @@ describe('Test database utils', () => {
       ast.addFilter('firstname', OP_EQUALS, 'Julius');
       ast.addFilter('shiftstartdatetime', OP_GT, '2019-06-20T12:00:00');
       ast.addFilter('shiftstartdatetime', OP_LTE, '2019-06-22T12:00:00');
-      const expectedQuery = `SELECT firstname FROM ${name} WHERE firstname = 'Julius' AND shiftstartdatetime > '2019-06-20T12:00:00' AND shiftstartdatetime <= '2019-06-22T12:00:00';`;
+      const expectedQuery = `SELECT firstname FROM ${name} WHERE firstname = $1 AND shiftstartdatetime > $2 AND shiftstartdatetime <= $3;`;
+      const expectedParams = ['Julius', '2019-06-20T12:00:00', '2019-06-22T12:00:00'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 
@@ -270,8 +280,8 @@ describe('Test database utils', () => {
       ast.addFilter('id', OP_EQUALS, id);
       ast.addColumns(['email', 'roles']);
       ast.addRow(body);
-      const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = '${id}';`;
-      const expectedParams = [body.email, JSON.stringify(body.roles)];
+      const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = $3;`;
+      const expectedParams = [body.email, JSON.stringify(body.roles), id];
 
       const { query, parameters } = generateCode(ast);
 
@@ -288,8 +298,8 @@ describe('Test database utils', () => {
       ast.addColumns(['age', 'email', 'roles']);
       ast.addRow(body);
       ast.returnData();
-      const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = '${id}' RETURNING *;`;
-      const expectedParams = [body.age, body.email, JSON.stringify(body.roles)];
+      const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = $4 RETURNING *;`;
+      const expectedParams = [body.age, body.email, JSON.stringify(body.roles), id];
 
       const { query, parameters } = generateCode(ast);
 
@@ -307,8 +317,8 @@ describe('Test database utils', () => {
       ast.addFilter('id', OP_EQUALS, id);
       ast.addColumns('firstname');
       ast.addRow(body);
-      const expectedParams = ['John'];
-      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE firstname = '${firstname}' AND id = '${id}';`;
+      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE firstname = $2 AND id = $3;`;
+      const expectedParams = ['John', firstname, id];
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
@@ -333,11 +343,13 @@ describe('Test database utils', () => {
       const name = 'roles';
       const ast = new AbstractSyntaxTree(DELETE_QUERY, name, TABLE);
       ast.addFilter('email', OP_EQUALS, 'manager@mail.com');
-      const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com';`;
+      const expectedQuery = `DELETE FROM ${name} WHERE email = $1;`;
+      const expectedParams = ['manager@mail.com'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring to delete a row matching the email address and id', () => {
@@ -345,11 +357,13 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(DELETE_QUERY, name, TABLE);
       ast.addFilter('email', OP_EQUALS, 'manager@mail.com');
       ast.addFilter('id', OP_EQUALS, 123);
-      const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com' AND id = 123;`;
+      const expectedQuery = `DELETE FROM ${name} WHERE email = $1 AND id = $2;`;
+      const expectedParams = ['manager@mail.com', 123];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 
@@ -398,11 +412,13 @@ describe('Test database utils', () => {
       ast.addColumns('email');
       ast.addFilter('lastname', OP_EQUALS, 'Smith');
       ast.addArguments(body);
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = $1;`;
+      const expectedParams = ['Smith'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 
@@ -414,11 +430,13 @@ describe('Test database utils', () => {
       ast.addFilter('name', OP_EQUALS, 'Tilbury 1');
       ast.addFilter('city', OP_EQUALS, 'London');
       ast.limit(5);
-      const expectedQuery = `SELECT name, city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
+      const expectedQuery = `SELECT name, city FROM ${name} WHERE name = $1 AND city = $2 LIMIT 5;`;
+      const expectedParams = ['Tilbury 1', 'London'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
@@ -426,11 +444,13 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
       ast.addFilter('firstname', OP_EQUALS, 'Pedro');
       ast.limit(1);
-      const expectedQuery = `SELECT * FROM ${name} WHERE firstname = 'Pedro' LIMIT 1;`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE firstname = $1 LIMIT 1;`;
+      const expectedParams = ['Pedro'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with all columns and a limit of 1 row', () => {

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -34,7 +34,7 @@ describe('Test database utils', () => {
       ast.addColumns(['developer', 'linemanager']);
       const expectedQuery = `SELECT developer, linemanager FROM ${name};`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -45,7 +45,7 @@ describe('Test database utils', () => {
       ast.addColumns(['firstname', 'lastname', 'email']);
       const expectedQuery = `SELECT firstname, lastname, email FROM ${name};`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -54,7 +54,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = 'select=';
       const expectedQuery = '';
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -64,7 +64,7 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
       const expectedQuery = `SELECT * FROM ${name};`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -75,7 +75,7 @@ describe('Test database utils', () => {
       ast.addFilter('name', OP_EQUALS, 'Tilbury 2');
       const expectedQuery = `SELECT * FROM ${name} WHERE name = 'Tilbury 2';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -84,7 +84,7 @@ describe('Test database utils', () => {
       const name = 'users';
       const queryParams = 'email=eq.john@mail.com';
       const expectedQuery = `SELECT * FROM ${name} WHERE email = 'john@mail.com';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -95,7 +95,7 @@ describe('Test database utils', () => {
       ast.addFilter('name', OP_IS, NULL);
       const expectedQuery = `SELECT * FROM ${name} WHERE name IS NULL;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -107,7 +107,7 @@ describe('Test database utils', () => {
       ast.addFilter('staffid', OP_IN, ['123', '222']);
       const expectedQuery = `SELECT email FROM ${name} WHERE staffid IN ('123', '222');`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -119,7 +119,7 @@ describe('Test database utils', () => {
       ast.addFilter('staffid', OP_IN, ['123', '222']);
       const expectedQuery = `SELECT email, name FROM ${name} WHERE staffid IN ('123', '222');`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -131,7 +131,7 @@ describe('Test database utils', () => {
       ast.addFilter('continent', OP_EQUALS, 'Asia');
       const expectedQuery = `SELECT * FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -144,7 +144,7 @@ describe('Test database utils', () => {
       ast.addFilter('continent', OP_EQUALS, 'Asia');
       const expectedQuery = `SELECT name, id, continent FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -153,7 +153,7 @@ describe('Test database utils', () => {
       const name = 'view_rolemembers';
       const queryParams = 'email=eq.manager@mail.com';
       const expectedQuery = `SELECT * FROM ${name} WHERE email = 'manager@mail.com';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -165,7 +165,7 @@ describe('Test database utils', () => {
       ast.addFilter('shiftstartdatetime', OP_LT, '2019-06-22T12:00:00');
       const expectedQuery = `SELECT * FROM ${name} WHERE shiftstartdatetime >= '2019-06-20T12:00:00' AND shiftstartdatetime < '2019-06-22T12:00:00';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -179,7 +179,7 @@ describe('Test database utils', () => {
       ast.addFilter('shiftstartdatetime', OP_LTE, '2019-06-22T12:00:00');
       const expectedQuery = `SELECT firstname FROM ${name} WHERE firstname = 'Julius' AND shiftstartdatetime > '2019-06-20T12:00:00' AND shiftstartdatetime <= '2019-06-22T12:00:00';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -194,7 +194,7 @@ describe('Test database utils', () => {
       ast.addRow(body);
       const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ('John', '34', 'john@mail.com', '["linemanager","systemuser"]');`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -209,7 +209,7 @@ describe('Test database utils', () => {
 
       const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com') RETURNING *;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -226,7 +226,7 @@ describe('Test database utils', () => {
       ast.addRow(body[1]);
       const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com');`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -244,7 +244,7 @@ describe('Test database utils', () => {
       ast.returnData();
       const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com') RETURNING *;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -261,7 +261,7 @@ describe('Test database utils', () => {
       ast.addRow(body);
       const expectedQuery = `UPDATE ${name} SET email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -277,7 +277,7 @@ describe('Test database utils', () => {
       ast.returnData();
       const expectedQuery = `UPDATE ${name} SET age='${body.age}', email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}' RETURNING *;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -293,7 +293,7 @@ describe('Test database utils', () => {
       ast.addColumns('firstname');
       ast.addRow(body);
       const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE firstname = '${firstname}' AND id = '${id}';`;
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -305,7 +305,7 @@ describe('Test database utils', () => {
       const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
       const body = { 'firstname': 'John' };
       const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE id = '${id}';`;
-      const query = updateQueryBuilder({ body, name, id, queryParams });
+      const { query, parameters } = updateQueryBuilder({ body, name, id, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -318,7 +318,7 @@ describe('Test database utils', () => {
       ast.addFilter('email', OP_EQUALS, 'manager@mail.com');
       const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -330,7 +330,7 @@ describe('Test database utils', () => {
       ast.addFilter('id', OP_EQUALS, 123);
       const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com' AND id = 123;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -344,7 +344,7 @@ describe('Test database utils', () => {
       ast.addArguments(body);
       const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>'daisy@mail.com');`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -356,7 +356,7 @@ describe('Test database utils', () => {
       ast.addArguments(body);
       const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -369,7 +369,7 @@ describe('Test database utils', () => {
       ast.addColumns('email');
       ast.addArguments(body);
       const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -383,7 +383,7 @@ describe('Test database utils', () => {
       ast.addArguments(body);
       const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -399,7 +399,7 @@ describe('Test database utils', () => {
       ast.limit(5);
       const expectedQuery = `SELECT name, city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -411,7 +411,7 @@ describe('Test database utils', () => {
       ast.limit(1);
       const expectedQuery = `SELECT * FROM ${name} WHERE firstname = 'Pedro' LIMIT 1;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -422,7 +422,7 @@ describe('Test database utils', () => {
       ast.limit(1);
       const expectedQuery = `SELECT * FROM ${name} LIMIT 1;`;
 
-      const query = generateCode(ast);
+      const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -390,54 +390,41 @@ describe('Test database utils', () => {
   });
 
   describe('v2 GET - querystring builder', () => {
-    xit('Should return a querystring with two columns selected filtered by name and city and a limit of 5 rows', () => {
+    it('Should return a querystring with two columns selected filtered by name and city and a limit of 5 rows', () => {
       const name = 'roles';
-      const queryParams = {
-        'select': 'name,city',
-        'filter': [
-          'name=eq.Tilbury 1',
-          'city=eq.London',
-        ],
-        'limit': '5',
-      };
-      const expectedQuery = `SELECT name,city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
-      const query = selectQueryBuilderV2({ name, queryParams });
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addColumns(['name', 'city']);
+      ast.addFilter('name', OP_EQUALS, 'Tilbury 1');
+      ast.addFilter('city', OP_EQUALS, 'London');
+      ast.limit(5);
+      const expectedQuery = `SELECT name, city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
 
-    xit('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
+    it('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
       const name = 'roles';
-      const queryParams = {
-        'filter': [
-          'firstname=eq.Pedro',
-        ],
-        'limit': '1',
-      };
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addFilter('firstname', OP_EQUALS, 'Pedro');
+      ast.limit(1);
       const expectedQuery = `SELECT * FROM ${name} WHERE firstname = 'Pedro' LIMIT 1;`;
-      const query = selectQueryBuilderV2({ name, queryParams });
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
 
-    xit('Should return a querystring with all columns and a limit of 1 row', () => {
+    it('Should return a querystring with all columns and a limit of 1 row', () => {
       const name = 'roles';
-      const queryParams = { 'limit': '1' };
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.limit(1);
       const expectedQuery = `SELECT * FROM ${name} LIMIT 1;`;
-      const query = selectQueryBuilderV2({ name, queryParams });
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
-    });
-
-    xit('Should return an empty querystring if there is more than one select in the query params', () => {
-      const name = 'roles';
-      const queryParams = {
-        'limit': ['3', '77'],
-        'select': ['name,age', 'location'],
-      };
-      const query = selectQueryBuilderV2({ name, queryParams });
-
-      expect(query).to.equal('');
     });
   });
 });

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -105,11 +105,13 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
       ast.addColumns('email');
       ast.addFilter('staffid', OP_IN, ['123', '222']);
-      const expectedQuery = `SELECT email FROM ${name} WHERE staffid IN ('123', '222');`;
+      const expectedQuery = `SELECT email FROM ${name} WHERE staffid IN ($1, $2);`;
+      const expectedParams = ['123', '222'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with two columns selected filtering by an array', () => {
@@ -117,11 +119,13 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
       ast.addColumns(['email', 'name']);
       ast.addFilter('staffid', OP_IN, ['123', '222']);
-      const expectedQuery = `SELECT email, name FROM ${name} WHERE staffid IN ('123', '222');`;
+      const expectedQuery = `SELECT email, name FROM ${name} WHERE staffid IN ($1, $2);`;
+      const expectedParams = ['123', '222'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for all data where id and continent match the provided values', () => {
@@ -192,11 +196,13 @@ describe('Test database utils', () => {
       const ast = new AbstractSyntaxTree(INSERT_QUERY, name, TABLE);
       ast.addColumns(['name', 'age', 'email', 'roles']);
       ast.addRow(body);
-      const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ('John', '34', 'john@mail.com', '["linemanager","systemuser"]');`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ($1, $2, $3, $4);`;
+      const expectedParams = ['John', 34, 'john@mail.com', '["linemanager","systemuser"]'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with option to return all inserted data', () => {
@@ -206,12 +212,13 @@ describe('Test database utils', () => {
       ast.addColumns(['name', 'age', 'email']);
       ast.addRow(body);
       ast.returnData();
-
-      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com') RETURNING *;`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ($1, $2, $3) RETURNING *;`;
+      const expectedParams = ['John', 34, 'john@mail.com'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with option to insert multiple rows, without returning the data inserted', () => {
@@ -224,11 +231,13 @@ describe('Test database utils', () => {
       ast.addColumns(['name', 'age', 'email']);
       ast.addRow(body[0]);
       ast.addRow(body[1]);
-      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com');`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ($1, $2, $3), ($4, $5, $6);`;
+      const expectedParams = ['John', 34, 'john@mail.com', 'Rachel', 32, 'rachel@mail.com'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with option to insert multiple rows, returning the data inserted', () => {
@@ -242,11 +251,13 @@ describe('Test database utils', () => {
       ast.addRow(body[0]);
       ast.addRow(body[1]);
       ast.returnData();
-      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com') RETURNING *;`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ($1, $2, $3), ($4, $5, $6) RETURNING *;`;
+      const expectedParams = ['John', 34, 'john@mail.com', 'Rachel', 32, 'rachel@mail.com'];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -1,0 +1,390 @@
+const { expect } = require('chai');
+
+// local imports
+const {
+  deleteQueryBuilder,
+  insertIntoQueryBuilder,
+  selectQueryBuilder,
+  selectQueryBuilderV2,
+  updateQueryBuilder,
+} = require('../../../app/db/utils');
+
+const {
+  AbstractSyntaxTree,
+  SELECT_QUERY,
+  OP_EQUALS,
+  OP_GT,
+  OP_GTE,
+  OP_IN,
+  OP_IS,
+  OP_LT,
+  OP_LTE,
+  NULL,
+  TABLE,
+} = require('../../../app/db/ast');
+const { generateCode } = require('../../../app/db/codegen');
+
+describe('Test database utils', () => {
+  describe('v1 GET - querystring builder', () => {
+    it('Should return a querystring with two columns selected', () => {
+      const name = 'roles';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addColumns(['developer', 'linemanager']);
+      const expectedQuery = `SELECT developer, linemanager FROM ${name};`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with three columns selected', () => {
+      const name = 'roles';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addColumns(['firstname', 'lastname', 'email']);
+      const expectedQuery = `SELECT firstname, lastname, email FROM ${name};`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    xit('Should return an empty querystring if no filters are passed', () => {
+      const name = 'roles';
+      const queryParams = 'select=';
+      const expectedQuery = '';
+      const query = selectQueryBuilder({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for all data', () => {
+      const name = 'users';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      const expectedQuery = `SELECT * FROM ${name};`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for all team data where name matches team name', () => {
+      const name = 'team';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addFilter('name', OP_EQUALS, 'Tilbury 2');
+      const expectedQuery = `SELECT * FROM ${name} WHERE name = 'Tilbury 2';`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    xit('Should return a querystring for all data where email matches user email', () => {
+      const name = 'users';
+      const queryParams = 'email=eq.john@mail.com';
+      const expectedQuery = `SELECT * FROM ${name} WHERE email = 'john@mail.com';`;
+      const query = selectQueryBuilder({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for all data where name is null', () => {
+      const name = 'users';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addFilter('name', OP_IS, NULL);
+      const expectedQuery = `SELECT * FROM ${name} WHERE name IS NULL;`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with a column selected filtering by an array', () => {
+      const name = 'users';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addColumns('email');
+      ast.addFilter('staffid', OP_IN, ['123', '222']);
+      const expectedQuery = `SELECT email FROM ${name} WHERE staffid IN ('123', '222');`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with two columns selected filtering by an array', () => {
+      const name = 'users';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addColumns(['email', 'name']);
+      ast.addFilter('staffid', OP_IN, ['123', '222']);
+      const expectedQuery = `SELECT email, name FROM ${name} WHERE staffid IN ('123', '222');`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for all data where id and continent match the provided values', () => {
+      const name = 'countries';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addFilter('id', OP_EQUALS, 3);
+      ast.addFilter('continent', OP_EQUALS, 'Asia');
+      const expectedQuery = `SELECT * FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with name, id and continent selected where id and continent match the provided values', () => {
+      const name = 'countries';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addColumns(['name', 'id', 'continent']);
+      ast.addFilter('id', OP_EQUALS, 3);
+      ast.addFilter('continent', OP_EQUALS, 'Asia');
+      const expectedQuery = `SELECT name, id, continent FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    xit('Should return a querystring witha select to a sql view with filtering parameters', () => {
+      const name = 'view_rolemembers';
+      const queryParams = 'email=eq.manager@mail.com';
+      const expectedQuery = `SELECT * FROM ${name} WHERE email = 'manager@mail.com';`;
+      const query = selectQueryBuilder({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for all data where shiftstartdatetime matches the date range values', () => {
+      const name = 'getoarrecords';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addFilter('shiftstartdatetime', OP_GTE, '2019-06-20T12:00:00');
+      ast.addFilter('shiftstartdatetime', OP_LT, '2019-06-22T12:00:00');
+      const expectedQuery = `SELECT * FROM ${name} WHERE shiftstartdatetime >= '2019-06-20T12:00:00' AND shiftstartdatetime < '2019-06-22T12:00:00';`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with name selected where shiftstartdatetime matches the date range values', () => {
+      const name = 'getoarrecords';
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, TABLE);
+      ast.addColumns('firstname');
+      ast.addFilter('firstname', OP_EQUALS, 'Julius');
+      ast.addFilter('shiftstartdatetime', OP_GT, '2019-06-20T12:00:00');
+      ast.addFilter('shiftstartdatetime', OP_LTE, '2019-06-22T12:00:00');
+      const expectedQuery = `SELECT firstname FROM ${name} WHERE firstname = 'Julius' AND shiftstartdatetime > '2019-06-20T12:00:00' AND shiftstartdatetime <= '2019-06-22T12:00:00';`;
+
+      const query = generateCode(ast);
+
+      expect(query).to.equal(expectedQuery);
+    });
+  });
+
+  describe('v1 POST - querystring builder', () => {
+    it('Should return a querystring to insert values into columns', () => {
+      const name = 'staff';
+      const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
+      const expectedQuery = `INSERT INTO ${name} (name,age,email,roles) VALUES ('John','34','john@mail.com','["linemanager","systemuser"]');`;
+      const query = insertIntoQueryBuilder({ name, body });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with option to return all inserted data', () => {
+      const name = 'staff';
+      const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com' };
+      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com') RETURNING *;`;
+      const prefer = 'return=representation';
+      const query = insertIntoQueryBuilder({ name, body, prefer });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with option to insert multiple rows, without returning the data inserted', () => {
+      const name = 'staff';
+      const body = [
+        { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
+        { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
+      ];
+      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com');`;
+      const query = insertIntoQueryBuilder({ name, body });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with option to insert multiple rows, returning the data inserted', () => {
+      const name = 'staff';
+      const body = [
+        { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
+        { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
+      ];
+      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com') RETURNING *;`;
+      const prefer = 'return=representation';
+      const query = insertIntoQueryBuilder({ name, body, prefer });
+
+      expect(query).to.equal(expectedQuery);
+    });
+  });
+
+  describe('v1 PATCH - querystring builder', () => {
+    it('Should return a querystring to update existing data matching an id', () => {
+      const name = 'identity';
+      const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
+      const body = { 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
+      const expectedQuery = `UPDATE ${name} SET email='${body.email}',roles=${JSON.stringify(body.roles)} WHERE id = '${id}';`;
+      const query = updateQueryBuilder({ body, name, id });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring to update existing data mathing an id, with option to return all updated data', () => {
+      const name = 'identity';
+      const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
+      const prefer = 'return=representation';
+      const body = { 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
+      const expectedQuery = `UPDATE ${name} SET age='${body.age}',email='${body.email}',roles=${JSON.stringify(body.roles)} WHERE id = '${id}' RETURNING *;`;
+      const query = updateQueryBuilder({ body, name, id, prefer });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring to update existing data matching query parameters', () => {
+      const name = 'identity';
+      const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
+      const firstname = 'Pedro';
+      const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
+      const body = { 'firstname': 'John' };
+      const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE firstname = '${firstname}' AND id = '${id}';`;
+      const query = updateQueryBuilder({ body, name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring to update existing data matching an id only, even if query parameters are provided', () => {
+      const name = 'identity';
+      const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
+      const firstname = 'Pedro';
+      const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
+      const body = { 'firstname': 'John' };
+      const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE id = '${id}';`;
+      const query = updateQueryBuilder({ body, name, id, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+  });
+
+  describe('v1 DELETE - querystring builder', () => {
+    it('Should return a querystring to delete a row matching the email address', () => {
+      const name = 'roles';
+      const queryParams = 'email=eq.manager@mail.com';
+      const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com';`;
+      const query = deleteQueryBuilder({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring to delete a row matching the email address and id', () => {
+      const name = 'roles';
+      const queryParams = 'email=eq.manager@mail.com,&id=eq.123';
+      const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com' AND id = 123;`;
+      const query = deleteQueryBuilder({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+  });
+
+  describe('v1 POST To View Function - querystring builder', () => {
+    it('Should return a querystring for a function view', () => {
+      const name = 'staffdetails';
+      const body = { 'argstaffemail': 'daisy@mail.com' };
+      const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>'daisy@mail.com');`;
+      const query = selectQueryBuilder({ name, body });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for a function view with multiple arguments', () => {
+      const name = 'staffdetails';
+      const body = { 'argfirstname': 'Andy', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
+      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const query = selectQueryBuilder({ name, body });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for a function view with multiple arguments and selected columns', () => {
+      const name = 'staffdetails';
+      const queryParams = 'select=email';
+      const body = { 'argfirstname': 'Lauren', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const query = selectQueryBuilder({ name, body, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring for a function view with multiple arguments selected columns and filtering parameters', () => {
+      const name = 'staffdetails';
+      const queryParams = 'select=email&lastname=eq.Smith';
+      const body = { 'argfirstname': 'John', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
+      const query = selectQueryBuilder({ name, body, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+  });
+
+  describe('v2 GET - querystring builder', () => {
+    it('Should return a querystring with two columns selected filtered by name and city and a limit of 5 rows', () => {
+      const name = 'roles';
+      const queryParams = {
+        'select': 'name,city',
+        'filter': [
+          'name=eq.Tilbury 1',
+          'city=eq.London',
+        ],
+        'limit': '5',
+      };
+      const expectedQuery = `SELECT name,city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
+      const name = 'roles';
+      const queryParams = {
+        'filter': [
+          'firstname=eq.Pedro',
+        ],
+        'limit': '1',
+      };
+      const expectedQuery = `SELECT * FROM ${name} WHERE firstname = 'Pedro' LIMIT 1;`;
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return a querystring with all columns and a limit of 1 row', () => {
+      const name = 'roles';
+      const queryParams = { 'limit': '1' };
+      const expectedQuery = `SELECT * FROM ${name} LIMIT 1;`;
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal(expectedQuery);
+    });
+
+    it('Should return an empty querystring if there is more than one select in the query params', () => {
+      const name = 'roles';
+      const queryParams = {
+        'limit': ['3', '77'],
+        'select': ['name,age', 'location'],
+      };
+      const query = selectQueryBuilderV2({ name, queryParams });
+
+      expect(query).to.equal('');
+    });
+  });
+});

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -2,8 +2,6 @@ const { expect } = require('chai');
 
 // local imports
 const {
-  deleteQueryBuilder,
-  insertIntoQueryBuilder,
   selectQueryBuilder,
   selectQueryBuilderV2,
   updateQueryBuilder,
@@ -11,6 +9,7 @@ const {
 
 const {
   AbstractSyntaxTree,
+  DELETE_QUERY,
   INSERT_QUERY,
   SELECT_QUERY,
   UPDATE_QUERY,
@@ -314,18 +313,23 @@ describe('Test database utils', () => {
   describe('v1 DELETE - querystring builder', () => {
     it('Should return a querystring to delete a row matching the email address', () => {
       const name = 'roles';
-      const queryParams = 'email=eq.manager@mail.com';
+      const ast = new AbstractSyntaxTree(DELETE_QUERY, name, TABLE);
+      ast.addFilter('email', OP_EQUALS, 'manager@mail.com');
       const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com';`;
-      const query = deleteQueryBuilder({ name, queryParams });
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
 
     it('Should return a querystring to delete a row matching the email address and id', () => {
       const name = 'roles';
-      const queryParams = 'email=eq.manager@mail.com,&id=eq.123';
+      const ast = new AbstractSyntaxTree(DELETE_QUERY, name, TABLE);
+      ast.addFilter('email', OP_EQUALS, 'manager@mail.com');
+      ast.addFilter('id', OP_EQUALS, 123);
       const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com' AND id = 123;`;
-      const query = deleteQueryBuilder({ name, queryParams });
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -270,11 +270,13 @@ describe('Test database utils', () => {
       ast.addFilter('id', OP_EQUALS, id);
       ast.addColumns(['email', 'roles']);
       ast.addRow(body);
-      const expectedQuery = `UPDATE ${name} SET email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}';`;
+      const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = '${id}';`;
+      const expectedParams = [body.email, JSON.stringify(body.roles)];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring to update existing data mathing an id, with option to return all updated data', () => {
@@ -286,11 +288,13 @@ describe('Test database utils', () => {
       ast.addColumns(['age', 'email', 'roles']);
       ast.addRow(body);
       ast.returnData();
-      const expectedQuery = `UPDATE ${name} SET age='${body.age}', email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}' RETURNING *;`;
+      const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = '${id}' RETURNING *;`;
+      const expectedParams = [body.age, body.email, JSON.stringify(body.roles)];
 
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring to update existing data matching query parameters', () => {
@@ -303,10 +307,12 @@ describe('Test database utils', () => {
       ast.addFilter('id', OP_EQUALS, id);
       ast.addColumns('firstname');
       ast.addRow(body);
-      const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE firstname = '${firstname}' AND id = '${id}';`;
+      const expectedParams = ['John'];
+      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE firstname = '${firstname}' AND id = '${id}';`;
       const { query, parameters } = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     xit('Should return a querystring to update existing data matching an id only, even if query parameters are provided', () => {

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -21,6 +21,7 @@ const {
   OP_LT,
   OP_LTE,
   NULL,
+  FUNCTION,
   TABLE,
 } = require('../../../app/db/ast');
 const { generateCode } = require('../../../app/db/codegen');
@@ -339,8 +340,11 @@ describe('Test database utils', () => {
     it('Should return a querystring for a function view', () => {
       const name = 'staffdetails';
       const body = { 'argstaffemail': 'daisy@mail.com' };
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, FUNCTION);
+      ast.addArguments(body);
       const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>'daisy@mail.com');`;
-      const query = selectQueryBuilder({ name, body });
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -348,8 +352,11 @@ describe('Test database utils', () => {
     it('Should return a querystring for a function view with multiple arguments', () => {
       const name = 'staffdetails';
       const body = { 'argfirstname': 'Andy', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
-      const query = selectQueryBuilder({ name, body });
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, FUNCTION);
+      ast.addArguments(body);
+      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -358,25 +365,32 @@ describe('Test database utils', () => {
       const name = 'staffdetails';
       const queryParams = 'select=email';
       const body = { 'argfirstname': 'Lauren', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
-      const query = selectQueryBuilder({ name, body, queryParams });
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, FUNCTION);
+      ast.addColumns('email');
+      ast.addArguments(body);
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
 
     it('Should return a querystring for a function view with multiple arguments selected columns and filtering parameters', () => {
       const name = 'staffdetails';
-      const queryParams = 'select=email&lastname=eq.Smith';
       const body = { 'argfirstname': 'John', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
-      const query = selectQueryBuilder({ name, body, queryParams });
+      const ast = new AbstractSyntaxTree(SELECT_QUERY, name, FUNCTION);
+      ast.addColumns('email');
+      ast.addFilter('lastname', OP_EQUALS, 'Smith');
+      ast.addArguments(body);
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
   });
 
   describe('v2 GET - querystring builder', () => {
-    it('Should return a querystring with two columns selected filtered by name and city and a limit of 5 rows', () => {
+    xit('Should return a querystring with two columns selected filtered by name and city and a limit of 5 rows', () => {
       const name = 'roles';
       const queryParams = {
         'select': 'name,city',
@@ -392,7 +406,7 @@ describe('Test database utils', () => {
       expect(query).to.equal(expectedQuery);
     });
 
-    it('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
+    xit('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
       const name = 'roles';
       const queryParams = {
         'filter': [
@@ -406,7 +420,7 @@ describe('Test database utils', () => {
       expect(query).to.equal(expectedQuery);
     });
 
-    it('Should return a querystring with all columns and a limit of 1 row', () => {
+    xit('Should return a querystring with all columns and a limit of 1 row', () => {
       const name = 'roles';
       const queryParams = { 'limit': '1' };
       const expectedQuery = `SELECT * FROM ${name} LIMIT 1;`;
@@ -415,7 +429,7 @@ describe('Test database utils', () => {
       expect(query).to.equal(expectedQuery);
     });
 
-    it('Should return an empty querystring if there is more than one select in the query params', () => {
+    xit('Should return an empty querystring if there is more than one select in the query params', () => {
       const name = 'roles';
       const queryParams = {
         'limit': ['3', '77'],

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -11,6 +11,7 @@ const {
 
 const {
   AbstractSyntaxTree,
+  INSERT_QUERY,
   SELECT_QUERY,
   OP_EQUALS,
   OP_GT,
@@ -187,8 +188,12 @@ describe('Test database utils', () => {
     it('Should return a querystring to insert values into columns', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `INSERT INTO ${name} (name,age,email,roles) VALUES ('John','34','john@mail.com','["linemanager","systemuser"]');`;
-      const query = insertIntoQueryBuilder({ name, body });
+      const ast = new AbstractSyntaxTree(INSERT_QUERY, name, TABLE);
+      ast.addColumns(['name', 'age', 'email', 'roles']);
+      ast.addRow(body);
+      const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ('John', '34', 'john@mail.com', '["linemanager","systemuser"]');`;
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -196,9 +201,14 @@ describe('Test database utils', () => {
     it('Should return a querystring with option to return all inserted data', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com' };
-      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com') RETURNING *;`;
-      const prefer = 'return=representation';
-      const query = insertIntoQueryBuilder({ name, body, prefer });
+      const ast = new AbstractSyntaxTree(INSERT_QUERY, name, TABLE);
+      ast.addColumns(['name', 'age', 'email']);
+      ast.addRow(body);
+      ast.returnData();
+
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com') RETURNING *;`;
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -209,8 +219,13 @@ describe('Test database utils', () => {
         { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
         { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
       ];
-      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com');`;
-      const query = insertIntoQueryBuilder({ name, body });
+      const ast = new AbstractSyntaxTree(INSERT_QUERY, name, TABLE);
+      ast.addColumns(['name', 'age', 'email']);
+      ast.addRow(body[0]);
+      ast.addRow(body[1]);
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com');`;
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });
@@ -221,9 +236,14 @@ describe('Test database utils', () => {
         { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
         { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
       ];
-      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com') RETURNING *;`;
-      const prefer = 'return=representation';
-      const query = insertIntoQueryBuilder({ name, body, prefer });
+      const ast = new AbstractSyntaxTree(INSERT_QUERY, name, TABLE);
+      ast.addColumns(['name', 'age', 'email']);
+      ast.addRow(body[0]);
+      ast.addRow(body[1]);
+      ast.returnData();
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com') RETURNING *;`;
+
+      const query = generateCode(ast);
 
       expect(query).to.equal(expectedQuery);
     });

--- a/test/app/db/codegen.test.js
+++ b/test/app/db/codegen.test.js
@@ -207,7 +207,7 @@ describe('Test database utils', () => {
       ast.addColumns(['name', 'age', 'email', 'roles']);
       ast.addRow(body);
       const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ($1, $2, $3, $4);`;
-      const expectedParams = ['John', 34, 'john@mail.com', '["linemanager","systemuser"]'];
+      const expectedParams = ['John', 34, 'john@mail.com', ["linemanager","systemuser"]];
 
       const { query, parameters } = generateCode(ast);
 
@@ -222,7 +222,7 @@ describe('Test database utils', () => {
       ast.addColumns(['name', 'age', 'email', 'roles']);
       ast.addRow(body);
       const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ($1, $2, $3, $4);`;
-      const expectedParams = ['John', 34, null, '["linemanager","systemuser"]'];
+      const expectedParams = ['John', 34, null, ["linemanager","systemuser"]];
 
       const { query, parameters } = generateCode(ast);
 
@@ -315,7 +315,7 @@ describe('Test database utils', () => {
       ast.addColumns(['email', 'roles']);
       ast.addRow(body);
       const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = $3;`;
-      const expectedParams = [body.email, JSON.stringify(body.roles), id];
+      const expectedParams = [body.email, body.roles, id];
 
       const { query, parameters } = generateCode(ast);
 
@@ -333,7 +333,7 @@ describe('Test database utils', () => {
       ast.addRow(body);
       ast.returnData();
       const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = $4 RETURNING *;`;
-      const expectedParams = [body.age, body.email, JSON.stringify(body.roles), id];
+      const expectedParams = [body.age, body.email, body.roles, id];
 
       const { query, parameters } = generateCode(ast);
 

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -305,7 +305,7 @@ describe('Test database utils', () => {
         ],
         'limit': '5',
       };
-      const expectedQuery = `SELECT name,city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
+      const expectedQuery = `SELECT name, city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
       const query = selectQueryBuilderV2({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
@@ -336,13 +336,22 @@ describe('Test database utils', () => {
 
     it('Should return an empty querystring if there is more than one select in the query params', () => {
       const name = 'roles';
-      const queryParams = {
-        'limit': ['3', '77'],
-        'select': ['name,age', 'location'],
-      };
-      const query = selectQueryBuilderV2({ name, queryParams });
+      const queryParams = { 'select': ['name,age', 'location'] };
+      try {
+        const query = selectQueryBuilderV2({ name, queryParams });
+      } catch (error) {
+        expect(error.message).to.equal('Only one value permitted for select and limit');
+      }
+    });
 
-      expect(query).to.equal('');
+    it('Should return an empty querystring if there is more than one limit in the query params', () => {
+      const name = 'roles';
+      const queryParams = { 'limit': ['3', '77'] };
+      try {
+        const query = selectQueryBuilderV2({ name, queryParams });
+      } catch (error) {
+        expect(error.message).to.equal('Only one value permitted for select and limit');
+      }
     });
   });
 });

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 // local imports
 const {
   deleteQueryBuilder,
+  functionQueryBuilder,
   insertIntoQueryBuilder,
   selectQueryBuilder,
   selectQueryBuilderV2,
@@ -29,13 +30,15 @@ describe('Test database utils', () => {
       expect(query).to.equal(expectedQuery);
     });
 
-    it('Should return an empty querystring if no filters are passed', () => {
+    it('Should throw an exception if no filters are passed', () => {
       const name = 'roles';
       const queryParams = 'select=';
       const expectedQuery = '';
-      const query = selectQueryBuilder({ name, queryParams });
-
-      expect(query).to.equal(expectedQuery);
+      try {
+        const query = selectQueryBuilder({ name, queryParams });
+      } catch (err) {
+        expect(err.message).to.equal('Select clause specified with no columns');
+      }
     });
 
     it('Should return a querystring for all data', () => {
@@ -189,7 +192,7 @@ describe('Test database utils', () => {
       const name = 'identity';
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const body = { 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `UPDATE ${name} SET email='${body.email}',roles=${JSON.stringify(body.roles)} WHERE id = '${id}';`;
+      const expectedQuery = `UPDATE ${name} SET email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}';`;
       const query = updateQueryBuilder({ body, name, id });
 
       expect(query).to.equal(expectedQuery);
@@ -200,7 +203,7 @@ describe('Test database utils', () => {
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const prefer = 'return=representation';
       const body = { 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `UPDATE ${name} SET age='${body.age}',email='${body.email}',roles=${JSON.stringify(body.roles)} WHERE id = '${id}' RETURNING *;`;
+      const expectedQuery = `UPDATE ${name} SET age='${body.age}', email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}' RETURNING *;`;
       const query = updateQueryBuilder({ body, name, id, prefer });
 
       expect(query).to.equal(expectedQuery);
@@ -256,7 +259,7 @@ describe('Test database utils', () => {
       const name = 'staffdetails';
       const body = { 'argstaffemail': 'daisy@mail.com' };
       const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>'daisy@mail.com');`;
-      const query = selectQueryBuilder({ name, body });
+      const query = functionQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -264,8 +267,8 @@ describe('Test database utils', () => {
     it('Should return a querystring for a function view with multiple arguments', () => {
       const name = 'staffdetails';
       const body = { 'argfirstname': 'Andy', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
-      const query = selectQueryBuilder({ name, body });
+      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const query = functionQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -274,8 +277,8 @@ describe('Test database utils', () => {
       const name = 'staffdetails';
       const queryParams = 'select=email';
       const body = { 'argfirstname': 'Lauren', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
-      const query = selectQueryBuilder({ name, body, queryParams });
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const query = functionQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -284,8 +287,8 @@ describe('Test database utils', () => {
       const name = 'staffdetails';
       const queryParams = 'select=email&lastname=eq.Smith';
       const body = { 'argfirstname': 'John', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John',argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
-      const query = selectQueryBuilder({ name, body, queryParams });
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
+      const query = functionQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -80,19 +80,23 @@ describe('Test database utils', () => {
     it('Should return a querystring with a column selected filtering by an array', () => {
       const name = 'users';
       const queryParams = 'select=email&staffid=in.%28123,222%29';
-      const expectedQuery = `SELECT email FROM ${name} WHERE staffid IN ('123', '222');`;
+      const expectedQuery = `SELECT email FROM ${name} WHERE staffid IN ($1, $2);`;
+      const expectedParams = ['123', '222'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with two columns selected filtering by an array', () => {
       const name = 'users';
       const queryParams = 'select=email,name&staffid=in.%28123,222%29';
-      const expectedQuery = `SELECT email, name FROM ${name} WHERE staffid IN ('123', '222');`;
+      const expectedQuery = `SELECT email, name FROM ${name} WHERE staffid IN ($1, $2);`;
+      const expectedParams = ['123', '222'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for all data where id and continent match the provided values', () => {
@@ -145,20 +149,24 @@ describe('Test database utils', () => {
     it('Should return a querystring to insert values into columns', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ('John', '34', 'john@mail.com', '["linemanager","systemuser"]');`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ($1, $2, $3, $4);`;
+      const expectedParams = ['John', 34, 'john@mail.com', '["linemanager","systemuser"]'];
       const { query, parameters } = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with option to return all inserted data', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com' };
-      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com') RETURNING *;`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ($1, $2, $3) RETURNING *;`;
+      const expectedParams = ['John', 34, 'john@mail.com'];
       const prefer = 'return=representation';
       const { query, parameters } = insertIntoQueryBuilder({ name, body, prefer });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with option to insert multiple rows, without returning the data inserted', () => {
@@ -167,10 +175,12 @@ describe('Test database utils', () => {
         { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
         { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
       ];
-      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com');`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ($1, $2, $3), ($4, $5, $6);`;
+      const expectedParams = ['John', 34, 'john@mail.com', 'Rachel', 32, 'rachel@mail.com'];
       const { query, parameters } = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with option to insert multiple rows, returning the data inserted', () => {
@@ -179,11 +189,13 @@ describe('Test database utils', () => {
         { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
         { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
       ];
-      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com') RETURNING *;`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ($1, $2, $3), ($4, $5, $6) RETURNING *;`;
+      const expectedParams = ['John', 34, 'john@mail.com', 'Rachel', 32, 'rachel@mail.com'];
       const prefer = 'return=representation';
       const { query, parameters } = insertIntoQueryBuilder({ name, body, prefer });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -145,7 +145,7 @@ describe('Test database utils', () => {
     it('Should return a querystring to insert values into columns', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `INSERT INTO ${name} (name,age,email,roles) VALUES ('John','34','john@mail.com','["linemanager","systemuser"]');`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ('John', '34', 'john@mail.com', '["linemanager","systemuser"]');`;
       const query = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
@@ -154,7 +154,7 @@ describe('Test database utils', () => {
     it('Should return a querystring with option to return all inserted data', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com' };
-      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com') RETURNING *;`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com') RETURNING *;`;
       const prefer = 'return=representation';
       const query = insertIntoQueryBuilder({ name, body, prefer });
 
@@ -167,7 +167,7 @@ describe('Test database utils', () => {
         { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
         { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
       ];
-      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com');`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com');`;
       const query = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
@@ -179,7 +179,7 @@ describe('Test database utils', () => {
         { 'name': 'John', 'age': 34, 'email': 'john@mail.com' },
         { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
       ];
-      const expectedQuery = `INSERT INTO ${name} (name,age,email) VALUES ('John','34','john@mail.com'),('Rachel','32','rachel@mail.com') RETURNING *;`;
+      const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com') RETURNING *;`;
       const prefer = 'return=representation';
       const query = insertIntoQueryBuilder({ name, body, prefer });
 

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -16,7 +16,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = 'select=developer,linemanager';
       const expectedQuery = `SELECT developer, linemanager FROM ${name};`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -25,7 +25,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = 'select=firstname,lastname,email';
       const expectedQuery = `SELECT firstname, lastname, email FROM ${name};`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -35,7 +35,7 @@ describe('Test database utils', () => {
       const queryParams = 'select=';
       const expectedQuery = '';
       try {
-        const query = selectQueryBuilder({ name, queryParams });
+        const { query, parameters } = selectQueryBuilder({ name, queryParams });
       } catch (err) {
         expect(err.message).to.equal('Select clause specified with no columns');
       }
@@ -45,7 +45,7 @@ describe('Test database utils', () => {
       const name = 'users';
       const queryParams = '';
       const expectedQuery = `SELECT * FROM ${name};`;
-      const query = selectQueryBuilder({ name });
+      const { query, parameters } = selectQueryBuilder({ name });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -54,7 +54,7 @@ describe('Test database utils', () => {
       const name = 'team';
       const queryParams = 'name=eq.Tilbury%202';
       const expectedQuery = `SELECT * FROM ${name} WHERE name = 'Tilbury 2';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -63,7 +63,7 @@ describe('Test database utils', () => {
       const name = 'users';
       const queryParams = 'email=eq.john@mail.com';
       const expectedQuery = `SELECT * FROM ${name} WHERE email = 'john@mail.com';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -72,7 +72,7 @@ describe('Test database utils', () => {
       const name = 'users';
       const queryParams = 'name=eq.null';
       const expectedQuery = `SELECT * FROM ${name} WHERE name IS NULL;`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -81,7 +81,7 @@ describe('Test database utils', () => {
       const name = 'users';
       const queryParams = 'select=email&staffid=in.%28123,222%29';
       const expectedQuery = `SELECT email FROM ${name} WHERE staffid IN ('123', '222');`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -90,7 +90,7 @@ describe('Test database utils', () => {
       const name = 'users';
       const queryParams = 'select=email,name&staffid=in.%28123,222%29';
       const expectedQuery = `SELECT email, name FROM ${name} WHERE staffid IN ('123', '222');`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -99,7 +99,7 @@ describe('Test database utils', () => {
       const name = 'countries';
       const queryParams = 'id=eq.3,&continent=eq.Asia';
       const expectedQuery = `SELECT * FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -108,7 +108,7 @@ describe('Test database utils', () => {
       const name = 'countries';
       const queryParams = 'select=name,id,continent&id=eq.3,&continent=eq.Asia';
       const expectedQuery = `SELECT name, id, continent FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -117,7 +117,7 @@ describe('Test database utils', () => {
       const name = 'view_rolemembers';
       const queryParams = 'email=eq.manager@mail.com';
       const expectedQuery = `SELECT * FROM ${name} WHERE email = 'manager@mail.com';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -126,7 +126,7 @@ describe('Test database utils', () => {
       const name = 'getoarrecords';
       const queryParams = 'shiftstartdatetime=gte.2019-06-20T12:00:00,&shiftstartdatetime=lt.2019-06-22T12:00:00';
       const expectedQuery = `SELECT * FROM ${name} WHERE shiftstartdatetime >= '2019-06-20T12:00:00' AND shiftstartdatetime < '2019-06-22T12:00:00';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -135,7 +135,7 @@ describe('Test database utils', () => {
       const name = 'getoarrecords';
       const queryParams = 'select=firstname&firstname=eq.Julius,&shiftstartdatetime=gt.2019-06-20T12:00:00,&shiftstartdatetime=lte.2019-06-22T12:00:00';
       const expectedQuery = `SELECT firstname FROM ${name} WHERE firstname = 'Julius' AND shiftstartdatetime > '2019-06-20T12:00:00' AND shiftstartdatetime <= '2019-06-22T12:00:00';`;
-      const query = selectQueryBuilder({ name, queryParams });
+      const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -146,7 +146,7 @@ describe('Test database utils', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ('John', '34', 'john@mail.com', '["linemanager","systemuser"]');`;
-      const query = insertIntoQueryBuilder({ name, body });
+      const { query, parameters } = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -156,7 +156,7 @@ describe('Test database utils', () => {
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com' };
       const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com') RETURNING *;`;
       const prefer = 'return=representation';
-      const query = insertIntoQueryBuilder({ name, body, prefer });
+      const { query, parameters } = insertIntoQueryBuilder({ name, body, prefer });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -168,7 +168,7 @@ describe('Test database utils', () => {
         { 'name': 'Rachel', 'age': 32, 'email': 'rachel@mail.com' },
       ];
       const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com');`;
-      const query = insertIntoQueryBuilder({ name, body });
+      const { query, parameters } = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -181,7 +181,7 @@ describe('Test database utils', () => {
       ];
       const expectedQuery = `INSERT INTO ${name} (name, age, email) VALUES ('John', '34', 'john@mail.com'), ('Rachel', '32', 'rachel@mail.com') RETURNING *;`;
       const prefer = 'return=representation';
-      const query = insertIntoQueryBuilder({ name, body, prefer });
+      const { query, parameters } = insertIntoQueryBuilder({ name, body, prefer });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -193,7 +193,7 @@ describe('Test database utils', () => {
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const body = { 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `UPDATE ${name} SET email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}';`;
-      const query = updateQueryBuilder({ body, name, id });
+      const { query, parameters } = updateQueryBuilder({ body, name, id });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -204,7 +204,7 @@ describe('Test database utils', () => {
       const prefer = 'return=representation';
       const body = { 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `UPDATE ${name} SET age='${body.age}', email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}' RETURNING *;`;
-      const query = updateQueryBuilder({ body, name, id, prefer });
+      const { query, parameters } = updateQueryBuilder({ body, name, id, prefer });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -216,7 +216,7 @@ describe('Test database utils', () => {
       const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
       const body = { 'firstname': 'John' };
       const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE firstname = '${firstname}' AND id = '${id}';`;
-      const query = updateQueryBuilder({ body, name, queryParams });
+      const { query, parameters } = updateQueryBuilder({ body, name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -228,7 +228,7 @@ describe('Test database utils', () => {
       const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
       const body = { 'firstname': 'John' };
       const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE id = '${id}';`;
-      const query = updateQueryBuilder({ body, name, id, queryParams });
+      const { query, parameters } = updateQueryBuilder({ body, name, id, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -239,7 +239,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = 'email=eq.manager@mail.com';
       const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com';`;
-      const query = deleteQueryBuilder({ name, queryParams });
+      const { query, parameters } = deleteQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -248,7 +248,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = 'email=eq.manager@mail.com,&id=eq.123';
       const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com' AND id = 123;`;
-      const query = deleteQueryBuilder({ name, queryParams });
+      const { query, parameters } = deleteQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -259,7 +259,7 @@ describe('Test database utils', () => {
       const name = 'staffdetails';
       const body = { 'argstaffemail': 'daisy@mail.com' };
       const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>'daisy@mail.com');`;
-      const query = functionQueryBuilder({ name, body });
+      const { query, parameters } = functionQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -268,7 +268,7 @@ describe('Test database utils', () => {
       const name = 'staffdetails';
       const body = { 'argfirstname': 'Andy', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
       const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
-      const query = functionQueryBuilder({ name, body });
+      const { query, parameters } = functionQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -278,7 +278,7 @@ describe('Test database utils', () => {
       const queryParams = 'select=email';
       const body = { 'argfirstname': 'Lauren', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
       const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
-      const query = functionQueryBuilder({ name, body, queryParams });
+      const { query, parameters } = functionQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -288,7 +288,7 @@ describe('Test database utils', () => {
       const queryParams = 'select=email&lastname=eq.Smith';
       const body = { 'argfirstname': 'John', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
       const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
-      const query = functionQueryBuilder({ name, body, queryParams });
+      const { query, parameters } = functionQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -306,7 +306,7 @@ describe('Test database utils', () => {
         'limit': '5',
       };
       const expectedQuery = `SELECT name, city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
-      const query = selectQueryBuilderV2({ name, queryParams });
+      const { query, parameters } = selectQueryBuilderV2({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -320,7 +320,7 @@ describe('Test database utils', () => {
         'limit': '1',
       };
       const expectedQuery = `SELECT * FROM ${name} WHERE firstname = 'Pedro' LIMIT 1;`;
-      const query = selectQueryBuilderV2({ name, queryParams });
+      const { query, parameters } = selectQueryBuilderV2({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -329,7 +329,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = { 'limit': '1' };
       const expectedQuery = `SELECT * FROM ${name} LIMIT 1;`;
-      const query = selectQueryBuilderV2({ name, queryParams });
+      const { query, parameters } = selectQueryBuilderV2({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
     });
@@ -338,7 +338,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = { 'select': ['name,age', 'location'] };
       try {
-        const query = selectQueryBuilderV2({ name, queryParams });
+        const { query, parameters } = selectQueryBuilderV2({ name, queryParams });
       } catch (error) {
         expect(error.message).to.equal('Only one value permitted for select and limit');
       }
@@ -348,7 +348,7 @@ describe('Test database utils', () => {
       const name = 'roles';
       const queryParams = { 'limit': ['3', '77'] };
       try {
-        const query = selectQueryBuilderV2({ name, queryParams });
+        const { query, parameters } = selectQueryBuilderV2({ name, queryParams });
       } catch (error) {
         expect(error.message).to.equal('Only one value permitted for select and limit');
       }

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -170,6 +170,17 @@ describe('Test database utils', () => {
       expect(parameters).to.eql(expectedParams);
     });
 
+    it('Should return a querystring to insert values into columns with nulls', () => {
+      const name = 'staff';
+      const body = { 'name': 'John', 'age': 34, 'email': null, 'roles': ['linemanager', 'systemuser'] };
+      const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ($1, $2, $3, $4);`;
+      const expectedParams = ['John', 34, null, '["linemanager","systemuser"]'];
+      const { query, parameters } = insertIntoQueryBuilder({ name, body });
+
+      expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
+    });
+
     it('Should return a querystring with option to return all inserted data', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com' };
@@ -220,6 +231,19 @@ describe('Test database utils', () => {
       const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = $3;`;
       const expectedParams = [body.email, JSON.stringify(body.roles), id];
       const { query, parameters } = updateQueryBuilder({ body, name, id });
+
+      expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
+    });
+
+    it('Should return a querystring to update existing data mathing an id, with nulls', () => {
+      const name = 'identity';
+      const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
+      const prefer = 'return=representation';
+      const body = { 'age': 34, 'email': null, 'roles': ['linemanager', 'systemuser'] };
+      const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = $4 RETURNING *;`;
+      const expectedParams = [body.age, body.email, JSON.stringify(body.roles), id];
+      const { query, parameters } = updateQueryBuilder({ body, name, id, prefer });
 
       expect(query).to.equal(expectedQuery);
       expect(parameters).to.eql(expectedParams);
@@ -307,6 +331,17 @@ describe('Test database utils', () => {
       const body = { 'argfirstname': 'Andy', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
       const expectedQuery = `SELECT * FROM ${name}(argfirstname=>$1, argstaffid=>$2);`;
       const expectedParams = ['Andy', 'af4601db-1640-4ff2-a4cc-da44bce99226'];
+      const { query, parameters } = functionQueryBuilder({ name, body });
+
+      expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
+    });
+
+    it('Should return a querystring for a function view with null argument', () => {
+      const name = 'staffdetails';
+      const body = { 'argfirstname': null, 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
+      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>$1, argstaffid=>$2);`;
+      const expectedParams = [null, 'af4601db-1640-4ff2-a4cc-da44bce99226'];
       const { query, parameters } = functionQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -204,10 +204,12 @@ describe('Test database utils', () => {
       const name = 'identity';
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const body = { 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `UPDATE ${name} SET email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}';`;
+      const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = '${id}';`;
+      const expectedParams = [body.email, JSON.stringify(body.roles)];
       const { query, parameters } = updateQueryBuilder({ body, name, id });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring to update existing data mathing an id, with option to return all updated data', () => {
@@ -215,10 +217,12 @@ describe('Test database utils', () => {
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const prefer = 'return=representation';
       const body = { 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `UPDATE ${name} SET age='${body.age}', email='${body.email}', roles=${JSON.stringify(body.roles)} WHERE id = '${id}' RETURNING *;`;
+      const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = '${id}' RETURNING *;`;
+      const expectedParams = [body.age, body.email, JSON.stringify(body.roles)];
       const { query, parameters } = updateQueryBuilder({ body, name, id, prefer });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring to update existing data matching query parameters', () => {
@@ -227,10 +231,12 @@ describe('Test database utils', () => {
       const firstname = 'Pedro';
       const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
       const body = { 'firstname': 'John' };
-      const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE firstname = '${firstname}' AND id = '${id}';`;
+      const expectedParams = ['John'];
+      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE firstname = '${firstname}' AND id = '${id}';`;
       const { query, parameters } = updateQueryBuilder({ body, name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring to update existing data matching an id only, even if query parameters are provided', () => {
@@ -239,10 +245,11 @@ describe('Test database utils', () => {
       const firstname = 'Pedro';
       const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
       const body = { 'firstname': 'John' };
-      const expectedQuery = `UPDATE ${name} SET firstname='${body.firstname}' WHERE id = '${id}';`;
+      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE id = '${id}';`;
+      const expectedParams = ['John'];
       const { query, parameters } = updateQueryBuilder({ body, name, id, queryParams });
-
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -163,7 +163,7 @@ describe('Test database utils', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ($1, $2, $3, $4);`;
-      const expectedParams = ['John', 34, 'john@mail.com', '["linemanager","systemuser"]'];
+      const expectedParams = ['John', 34, 'john@mail.com', ["linemanager","systemuser"]];
       const { query, parameters } = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
@@ -174,7 +174,7 @@ describe('Test database utils', () => {
       const name = 'staff';
       const body = { 'name': 'John', 'age': 34, 'email': null, 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `INSERT INTO ${name} (name, age, email, roles) VALUES ($1, $2, $3, $4);`;
-      const expectedParams = ['John', 34, null, '["linemanager","systemuser"]'];
+      const expectedParams = ['John', 34, null, ["linemanager","systemuser"]];
       const { query, parameters } = insertIntoQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
@@ -229,7 +229,7 @@ describe('Test database utils', () => {
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const body = { 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = $3;`;
-      const expectedParams = [body.email, JSON.stringify(body.roles), id];
+      const expectedParams = [body.email, body.roles, id];
       const { query, parameters } = updateQueryBuilder({ body, name, id });
 
       expect(query).to.equal(expectedQuery);
@@ -242,7 +242,7 @@ describe('Test database utils', () => {
       const prefer = 'return=representation';
       const body = { 'age': 34, 'email': null, 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = $4 RETURNING *;`;
-      const expectedParams = [body.age, body.email, JSON.stringify(body.roles), id];
+      const expectedParams = [body.age, body.email, body.roles, id];
       const { query, parameters } = updateQueryBuilder({ body, name, id, prefer });
 
       expect(query).to.equal(expectedQuery);
@@ -255,7 +255,7 @@ describe('Test database utils', () => {
       const prefer = 'return=representation';
       const body = { 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
       const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = $4 RETURNING *;`;
-      const expectedParams = [body.age, body.email, JSON.stringify(body.roles), id];
+      const expectedParams = [body.age, body.email, body.roles, id];
       const { query, parameters } = updateQueryBuilder({ body, name, id, prefer });
 
       expect(query).to.equal(expectedQuery);

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -53,16 +53,19 @@ describe('Test database utils', () => {
     it('Should return a querystring for all team data where name matches team name', () => {
       const name = 'team';
       const queryParams = 'name=eq.Tilbury%202';
-      const expectedQuery = `SELECT * FROM ${name} WHERE name = 'Tilbury 2';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE name = $1;`;
+      const expectedParams = ['Tilbury 2'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for all data where email matches user email', () => {
       const name = 'users';
       const queryParams = 'email=eq.john@mail.com';
-      const expectedQuery = `SELECT * FROM ${name} WHERE email = 'john@mail.com';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE email = $1;`;
+      const expectedParams = ['john@mail.com'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
@@ -102,46 +105,56 @@ describe('Test database utils', () => {
     it('Should return a querystring for all data where id and continent match the provided values', () => {
       const name = 'countries';
       const queryParams = 'id=eq.3,&continent=eq.Asia';
-      const expectedQuery = `SELECT * FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE id = $1 AND continent = $2;`;
+      const expectedParams = [3, 'Asia'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with name, id and continent selected where id and continent match the provided values', () => {
       const name = 'countries';
       const queryParams = 'select=name,id,continent&id=eq.3,&continent=eq.Asia';
-      const expectedQuery = `SELECT name, id, continent FROM ${name} WHERE id = 3 AND continent = 'Asia';`;
+      const expectedQuery = `SELECT name, id, continent FROM ${name} WHERE id = $1 AND continent = $2;`;
+      const expectedParams = [3, 'Asia'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring witha select to a sql view with filtering parameters', () => {
       const name = 'view_rolemembers';
       const queryParams = 'email=eq.manager@mail.com';
-      const expectedQuery = `SELECT * FROM ${name} WHERE email = 'manager@mail.com';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE email = $1;`;
+      const expectedParams = ['manager@mail.com'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for all data where shiftstartdatetime matches the date range values', () => {
       const name = 'getoarrecords';
       const queryParams = 'shiftstartdatetime=gte.2019-06-20T12:00:00,&shiftstartdatetime=lt.2019-06-22T12:00:00';
-      const expectedQuery = `SELECT * FROM ${name} WHERE shiftstartdatetime >= '2019-06-20T12:00:00' AND shiftstartdatetime < '2019-06-22T12:00:00';`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE shiftstartdatetime >= $1 AND shiftstartdatetime < $2;`;
+      const expectedParams = ['2019-06-20T12:00:00', '2019-06-22T12:00:00'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with name selected where shiftstartdatetime matches the date range values', () => {
       const name = 'getoarrecords';
       const queryParams = 'select=firstname&firstname=eq.Julius,&shiftstartdatetime=gt.2019-06-20T12:00:00,&shiftstartdatetime=lte.2019-06-22T12:00:00';
-      const expectedQuery = `SELECT firstname FROM ${name} WHERE firstname = 'Julius' AND shiftstartdatetime > '2019-06-20T12:00:00' AND shiftstartdatetime <= '2019-06-22T12:00:00';`;
+      const expectedQuery = `SELECT firstname FROM ${name} WHERE firstname = $1 AND shiftstartdatetime > $2 AND shiftstartdatetime <= $3;`;
+      const expectedParams = ['Julius', '2019-06-20T12:00:00', '2019-06-22T12:00:00'];
       const { query, parameters } = selectQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 
@@ -204,8 +217,8 @@ describe('Test database utils', () => {
       const name = 'identity';
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const body = { 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = '${id}';`;
-      const expectedParams = [body.email, JSON.stringify(body.roles)];
+      const expectedQuery = `UPDATE ${name} SET email=$1, roles=$2 WHERE id = $3;`;
+      const expectedParams = [body.email, JSON.stringify(body.roles), id];
       const { query, parameters } = updateQueryBuilder({ body, name, id });
 
       expect(query).to.equal(expectedQuery);
@@ -217,8 +230,8 @@ describe('Test database utils', () => {
       const id = '2553b00e-3cb0-441d-b29d-17196491a1e5';
       const prefer = 'return=representation';
       const body = { 'age': 34, 'email': 'john@mail.com', 'roles': ['linemanager', 'systemuser'] };
-      const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = '${id}' RETURNING *;`;
-      const expectedParams = [body.age, body.email, JSON.stringify(body.roles)];
+      const expectedQuery = `UPDATE ${name} SET age=$1, email=$2, roles=$3 WHERE id = $4 RETURNING *;`;
+      const expectedParams = [body.age, body.email, JSON.stringify(body.roles), id];
       const { query, parameters } = updateQueryBuilder({ body, name, id, prefer });
 
       expect(query).to.equal(expectedQuery);
@@ -231,8 +244,8 @@ describe('Test database utils', () => {
       const firstname = 'Pedro';
       const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
       const body = { 'firstname': 'John' };
-      const expectedParams = ['John'];
-      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE firstname = '${firstname}' AND id = '${id}';`;
+      const expectedParams = ['John', firstname, id];
+      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE firstname = $2 AND id = $3;`;
       const { query, parameters } = updateQueryBuilder({ body, name, queryParams });
 
       expect(query).to.equal(expectedQuery);
@@ -245,8 +258,8 @@ describe('Test database utils', () => {
       const firstname = 'Pedro';
       const queryParams = `firstname=eq.${firstname},&id=eq.${id}`;
       const body = { 'firstname': 'John' };
-      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE id = '${id}';`;
-      const expectedParams = ['John'];
+      const expectedQuery = `UPDATE ${name} SET firstname=$1 WHERE id = $2;`;
+      const expectedParams = ['John', id];
       const { query, parameters } = updateQueryBuilder({ body, name, id, queryParams });
       expect(query).to.equal(expectedQuery);
       expect(parameters).to.eql(expectedParams);
@@ -257,19 +270,23 @@ describe('Test database utils', () => {
     it('Should return a querystring to delete a row matching the email address', () => {
       const name = 'roles';
       const queryParams = 'email=eq.manager@mail.com';
-      const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com';`;
+      const expectedQuery = `DELETE FROM ${name} WHERE email = $1;`;
+      const expectedParams = ['manager@mail.com'];
       const { query, parameters } = deleteQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring to delete a row matching the email address and id', () => {
       const name = 'roles';
       const queryParams = 'email=eq.manager@mail.com,&id=eq.123';
-      const expectedQuery = `DELETE FROM ${name} WHERE email = 'manager@mail.com' AND id = 123;`;
+      const expectedQuery = `DELETE FROM ${name} WHERE email = $1 AND id = $2;`;
+      const expectedParams = ['manager@mail.com', 123];
       const { query, parameters } = deleteQueryBuilder({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 
@@ -306,10 +323,12 @@ describe('Test database utils', () => {
       const name = 'staffdetails';
       const queryParams = 'select=email&lastname=eq.Smith';
       const body = { 'argfirstname': 'John', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = 'Smith';`;
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = $1;`;
+      const expectedParams = ['Smith'];
       const { query, parameters } = functionQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
   });
 
@@ -324,10 +343,13 @@ describe('Test database utils', () => {
         ],
         'limit': '5',
       };
-      const expectedQuery = `SELECT name, city FROM ${name} WHERE name = 'Tilbury 1' AND city = 'London' LIMIT 5;`;
+      const expectedQuery = `SELECT name, city FROM ${name} WHERE name = $1 AND city = $2 LIMIT 5;`;
+      const expectedParams = ['Tilbury 1', 'London'];
+
       const { query, parameters } = selectQueryBuilderV2({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with all columns filtering by firstname and a limit of 1 row', () => {
@@ -338,10 +360,13 @@ describe('Test database utils', () => {
         ],
         'limit': '1',
       };
-      const expectedQuery = `SELECT * FROM ${name} WHERE firstname = 'Pedro' LIMIT 1;`;
+      const expectedQuery = `SELECT * FROM ${name} WHERE firstname = $1 LIMIT 1;`;
+      const expectedParams = ['Pedro'];
+
       const { query, parameters } = selectQueryBuilderV2({ name, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring with all columns and a limit of 1 row', () => {

--- a/test/app/db/utils.test.js
+++ b/test/app/db/utils.test.js
@@ -294,37 +294,43 @@ describe('Test database utils', () => {
     it('Should return a querystring for a function view', () => {
       const name = 'staffdetails';
       const body = { 'argstaffemail': 'daisy@mail.com' };
-      const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>'daisy@mail.com');`;
+      const expectedQuery = `SELECT * FROM ${name}(argstaffemail=>$1);`;
+      const expectedParams = ['daisy@mail.com'];
       const { query, parameters } = functionQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for a function view with multiple arguments', () => {
       const name = 'staffdetails';
       const body = { 'argfirstname': 'Andy', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>'Andy', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const expectedQuery = `SELECT * FROM ${name}(argfirstname=>$1, argstaffid=>$2);`;
+      const expectedParams = ['Andy', 'af4601db-1640-4ff2-a4cc-da44bce99226'];
       const { query, parameters } = functionQueryBuilder({ name, body });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for a function view with multiple arguments and selected columns', () => {
       const name = 'staffdetails';
       const queryParams = 'select=email';
       const body = { 'argfirstname': 'Lauren', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'Lauren', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226');`;
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>$1, argstaffid=>$2);`;
+      const expectedParams = ['Lauren', 'af4601db-1640-4ff2-a4cc-da44bce99226'];
       const { query, parameters } = functionQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);
+      expect(parameters).to.eql(expectedParams);
     });
 
     it('Should return a querystring for a function view with multiple arguments selected columns and filtering parameters', () => {
       const name = 'staffdetails';
       const queryParams = 'select=email&lastname=eq.Smith';
       const body = { 'argfirstname': 'John', 'argstaffid': 'af4601db-1640-4ff2-a4cc-da44bce99226' };
-      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>'John', argstaffid=>'af4601db-1640-4ff2-a4cc-da44bce99226') WHERE lastname = $1;`;
-      const expectedParams = ['Smith'];
+      const expectedQuery = `SELECT email FROM ${name}(argfirstname=>$1, argstaffid=>$2) WHERE lastname = $3;`;
+      const expectedParams = ['John', 'af4601db-1640-4ff2-a4cc-da44bce99226', 'Smith'];
       const { query, parameters } = functionQueryBuilder({ name, body, queryParams });
 
       expect(query).to.equal(expectedQuery);


### PR DESCRIPTION
This lays the groundwork for using parameterised queries to fix issues with incorrect datatypes being passed to the DB (and, handily, avoid SQL injection attacks).

* Add a better defined interface between the code generation and parsing code
* Break out the SQL code generation from the parsing code
* wire up the first bit of the new code generation
* Slightly better error reporting. 