### PR TITLE
Update healthcheck logger level to silly

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -61,7 +61,7 @@ app.use((req, res, next) => {
 app.use('/v1', v1);
 app.use('/v2', v2);
 app.get('/_health', (req, res) => {
-  logger.verbose('API is Alive & Kicking!');
+  logger.silly('API is Alive & Kicking!');
   return res.status(200).json({ 'status': 'UP' });
 });
 


### PR DESCRIPTION
This PR updates the healthcheck log level to silly so that we don't keep seeing the healthcheck messages unnecessarily.